### PR TITLE
feat: batch invoices and cleanup

### DIFF
--- a/ops/mainnet/prod/variables.tf
+++ b/ops/mainnet/prod/variables.tf
@@ -43,7 +43,7 @@ variable "invoice_age" {
 variable "everclear_api_url" {
   description = "URL of the Everclear API"
   type        = string
-  default     = "https://api.everclear.org"
+  default     = "https://api.staging.everclear.org"
 }
 
 variable "relayer_url" {

--- a/packages/adapters/everclear/src/index.ts
+++ b/packages/adapters/everclear/src/index.ts
@@ -155,7 +155,7 @@ export class EverclearAdapter {
   }
 
   async createNewIntent(
-    params: NewIntentParams | NewIntentWithPermit2Params | (NewIntentParams | NewIntentWithPermit2Params)[]
+    params: NewIntentParams | NewIntentWithPermit2Params | (NewIntentParams | NewIntentWithPermit2Params)[],
   ): Promise<TransactionRequest> {
     try {
       const url = `${this.apiUrl}/intents`;

--- a/packages/adapters/everclear/src/index.ts
+++ b/packages/adapters/everclear/src/index.ts
@@ -154,7 +154,9 @@ export class EverclearAdapter {
     // ];
   }
 
-  async createNewIntent(params: NewIntentParams | NewIntentWithPermit2Params): Promise<TransactionRequest> {
+  async createNewIntent(
+    params: NewIntentParams | NewIntentWithPermit2Params | (NewIntentParams | NewIntentWithPermit2Params)[]
+  ): Promise<TransactionRequest> {
     try {
       const url = `${this.apiUrl}/intents`;
       const { data } = await axiosPost<TransactionRequest>(url, params);

--- a/packages/adapters/prometheus/src/index.ts
+++ b/packages/adapters/prometheus/src/index.ts
@@ -5,7 +5,10 @@ import { jsonifyError, Logger } from '@mark/logger';
 
 const InvoiceLabelKeys = ['origin', 'ticker', 'id', 'destination', 'reason', 'isSplit', 'splitCount'] as const;
 
-export type InvoiceLabels = Omit<Record<(typeof InvoiceLabelKeys)[number], string>, 'destination' | 'reason' | 'isSplit' | 'splitCount'> & {
+export type InvoiceLabels = Omit<
+  Record<(typeof InvoiceLabelKeys)[number], string>,
+  'destination' | 'reason' | 'isSplit' | 'splitCount'
+> & {
   destination?: string;
   reason?: InvalidPurchaseReasonConcise;
   isSplit?: string;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -65,7 +65,7 @@ export interface MarkConfiguration {
   environment: Environment;
   logLevel: LogLevel;
   supportedSettlementDomains: number[];
-  prioritizeOldestInvoice?: boolean;
+  forceOldestInvoice?: boolean;
   supportedAssets: string[];
   chains: Record<string, ChainConfiguration>; // keyed on chain id
   hub: Omit<HubConfig, 'confirmations' | 'subgraphUrls'>;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -65,6 +65,7 @@ export interface MarkConfiguration {
   environment: Environment;
   logLevel: LogLevel;
   supportedSettlementDomains: number[];
+  prioritizeOldestInvoice?: boolean;
   supportedAssets: string[];
   chains: Record<string, ChainConfiguration>; // keyed on chain id
   hub: Omit<HubConfig, 'confirmations' | 'subgraphUrls'>;

--- a/packages/core/src/types/intent.ts
+++ b/packages/core/src/types/intent.ts
@@ -8,6 +8,22 @@ export interface NewIntentParams {
   maxFee: string | number;
 }
 
+export interface OrderParams {
+  destinations: string[];
+  receiver: string;
+  inputAsset: string;
+  outputAsset: string;
+  amount: string | number;
+  maxFee: string | number;
+  ttl: string | number;
+  data: string;
+}
+
+export interface NewOrderParams {
+  fee: string | number;
+  intents: OrderParams[];
+}
+
 export interface Permit2Params {
   nonce: string | number;
   deadline: string | number;

--- a/packages/poller/src/helpers/contracts.ts
+++ b/packages/poller/src/helpers/contracts.ts
@@ -419,3 +419,64 @@ export const getERC20Contract = async (config: MarkConfiguration, chainId: strin
     client,
   });
 };
+
+export const feeAdapterAbi = [
+  {
+    inputs: [
+      { name: '_fee', type: 'uint256' },
+      {
+        name: '_params',
+        type: 'tuple[]',
+        components: [
+          { name: 'destinations', type: 'uint32[]' },
+          { name: 'receiver', type: 'address' },
+          { name: 'inputAsset', type: 'address' },
+          { name: 'outputAsset', type: 'address' },
+          { name: 'amount', type: 'uint256' },
+          { name: 'maxFee', type: 'uint24' },
+          { name: 'ttl', type: 'uint48' },
+          { name: 'data', type: 'bytes' },
+        ],
+      },
+    ],
+    name: 'newOrder',
+    outputs: [
+      { name: '_orderId', type: 'bytes32' },
+      { name: '_intentIds', type: 'bytes32[]' },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: 'orderId',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        name: 'sender',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        name: 'intentIds',
+        type: 'bytes32[]',
+      },
+      {
+        indexed: false,
+        name: 'tokenFee',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'nativeFee',
+        type: 'uint256',
+      },
+    ],
+    name: 'OrderCreated',
+    type: 'event',
+  },
+] as const;

--- a/packages/poller/src/helpers/intent.ts
+++ b/packages/poller/src/helpers/intent.ts
@@ -1,4 +1,4 @@
-import { MarkConfiguration, NewIntentParams } from '@mark/core';
+import { MarkConfiguration, NewIntentParams, NewIntentWithPermit2Params } from '@mark/core';
 import { getERC20Contract } from './contracts';
 import { encodeFunctionData, erc20Abi } from 'viem';
 import { TransactionReason } from '@mark/prometheus';
@@ -11,8 +11,22 @@ import {
 } from './permit2';
 import { prepareMulticall } from './multicall';
 import { MarkAdapters } from '../init';
+import { decodeEventLog } from 'viem';
 
 export const INTENT_ADDED_TOPIC0 = '0xefe68281645929e2db845c5b42e12f7c73485fb5f18737b7b29379da006fa5f7';
+export const ORDER_CREATED_TOPIC0 = '0xc5929cfdbbc98a41855839bee1396d17ee4a149e40d5c324b6f4332655f5cffd';
+
+const orderCreatedAbi = [{
+  type: 'event',
+  name: 'OrderCreated',
+  inputs: [
+    { indexed: true, type: 'bytes32', name: 'orderId' },
+    { indexed: true, type: 'address', name: 'initiator' },
+    { type: 'bytes32[]', name: 'intentIds' },
+    { type: 'uint256', name: 'tokenFee' },
+    { type: 'uint256', name: 'nativeFee' }
+  ]
+}] as const;
 
 /**
  * Uses the api to get the tx data and chainservice to send intents and approve assets if required.
@@ -43,13 +57,12 @@ export const sendIntents = async (
     throw new Error('Cannot process multiple intents with different input assets');
   }
 
-  const results: { transactionHash: string; chainId: string; intentId: string }[] = [];
-
   try {
-    // First, check if we need a token approval
-    // Get transaction data for the first intent to use for approval
+    // Get transaction data for the first intent to use for approval check
     const firstIntent = intents[0];
-    const txData = await everclear.createNewIntent(firstIntent);
+
+    // API call to get txdata for the newOrder call
+    const txData = await everclear.createNewIntent(intents as (NewIntentParams | NewIntentWithPermit2Params)[]);
 
     // Get total amount needed across all intents
     const totalAmount = intents.reduce((sum, intent) => {
@@ -126,6 +139,7 @@ export const sendIntents = async (
       token: intents[0].inputAsset,
     });
 
+    // Verify min amounts for all intents before sending the batch
     for (const intent of intents) {
       // Sanity check -- minAmounts < intent.amount
       const { minAmounts } = await everclear.getMinAmounts(invoiceId);
@@ -141,52 +155,82 @@ export const sendIntents = async (
         // then you would still be contributing to invoice to settlement. The invoice will be handled
         // again on the next polling cycle.
       }
-      // Fetch transaction data for creating the intent
-      const intentTxData = await everclear.createNewIntent(intent);
-
-      // Submit the create intent transaction
-      logger.info('Submitting create intent transaction', {
-        invoiceId,
-        requestId,
-        intent,
-        transaction: {
-          to: intentTxData.to,
-          value: intentTxData.value,
-          data: intentTxData.data,
-          from: intentTxData.from,
-          chain: intentTxData.chainId,
-        },
-      });
-
-      const intentTx = await chainService.submitAndMonitor(intentTxData.chainId.toString(), {
-        to: intentTxData.to as string,
-        value: intentTxData.value ?? '0',
-        data: intentTxData.data,
-        from: intentTxData.from ?? config.ownAddress,
-      });
-
-      // Get the intent id
-      const event = intentTx.logs.find((l) => l.topics[0].toLowerCase() === INTENT_ADDED_TOPIC0)!;
-      const intentId = event.topics[1];
-
-      logger.info('Create intent transaction sent successfully', {
-        invoiceId,
-        requestId,
-        intentTxHash: intentTx.transactionHash,
-        chainId: intent.origin,
-        intentId,
-      });
-      prometheus.updateGasSpent(
-        intent.origin,
-        TransactionReason.CreateIntent,
-        BigInt(intentTx.cumulativeGasUsed.mul(intentTx.effectiveGasPrice).toString()),
-      );
-
-      // Add result to the output array
-      results.push({ transactionHash: intentTx.transactionHash, chainId: intent.origin, intentId });
     }
+
+    // Submit the batch transaction
+    logger.info('Submitting batch create intent transaction', {
+      invoiceId,
+      requestId,
+      transaction: {
+        to: txData.to,
+        value: txData.value,
+        data: txData.data,
+        from: txData.from,
+        chain: txData.chainId,
+      },
+    });
+
+    const newOrderTx = await chainService.submitAndMonitor(txData.chainId.toString(), {
+      to: txData.to as string,
+      value: txData.value ?? '0',
+      data: txData.data,
+      from: txData.from ?? config.ownAddress,
+    });
+
+    // Find the OrderCreated event log
+    const orderCreatedLog = newOrderTx.logs.find((l) => l.topics[0].toLowerCase() === ORDER_CREATED_TOPIC0);
+    if (!orderCreatedLog) {
+      logger.warn('OrderCreated event not found in transaction logs, but transaction was successful', {
+        invoiceId,
+        requestId,
+        transactionHash: newOrderTx.transactionHash,
+        chainId: intents[0].origin,
+        logs: newOrderTx.logs,
+      });
+      
+      // Tx was successful but logs weren't fetched correctly - use the tx hash
+      // as the intentId so the process can continue
+      return [{
+        transactionHash: newOrderTx.transactionHash,
+        chainId: intents[0].origin,
+        intentId: newOrderTx.transactionHash,
+      }];
+    }
+
+    const { args } = decodeEventLog({
+      abi: orderCreatedAbi,
+      data: orderCreatedLog.data as `0x${string}`,
+      topics: orderCreatedLog.topics as [signature: `0x${string}`, ...args: `0x${string}`[]],
+    });
+
+    const { intentIds, tokenFee, nativeFee } = args;
+
+    logger.info('Batch create intent transaction sent successfully', {
+      invoiceId,
+      requestId,
+      batchTxHash: newOrderTx.transactionHash,
+      chainId: intents[0].origin,
+      orderId: args.orderId,
+      initiator: args.initiator,
+      intentIds,
+      tokenFee: tokenFee.toString(),
+      nativeFee: nativeFee.toString(),
+    });
+
+    prometheus.updateGasSpent(
+      intents[0].origin,
+      TransactionReason.CreateIntent,
+      BigInt(newOrderTx.cumulativeGasUsed.mul(newOrderTx.effectiveGasPrice).toString()),
+    );
+
+    // Return results for each intent in the batch
+    return intentIds.map((intentId) => ({
+      transactionHash: newOrderTx.transactionHash,
+      chainId: intents[0].origin,
+      intentId,
+    }));
   } catch (error) {
-    logger.error('Error processing intents', {
+    logger.error('Error processing batch intents', {
       invoiceId,
       requestId,
       error,
@@ -194,8 +238,6 @@ export const sendIntents = async (
     });
     throw error;
   }
-
-  return results;
 };
 
 /**

--- a/packages/poller/src/helpers/intent.ts
+++ b/packages/poller/src/helpers/intent.ts
@@ -16,17 +16,19 @@ import { decodeEventLog } from 'viem';
 export const INTENT_ADDED_TOPIC0 = '0xefe68281645929e2db845c5b42e12f7c73485fb5f18737b7b29379da006fa5f7';
 export const ORDER_CREATED_TOPIC0 = '0xc5929cfdbbc98a41855839bee1396d17ee4a149e40d5c324b6f4332655f5cffd';
 
-const orderCreatedAbi = [{
-  type: 'event',
-  name: 'OrderCreated',
-  inputs: [
-    { indexed: true, type: 'bytes32', name: 'orderId' },
-    { indexed: true, type: 'address', name: 'initiator' },
-    { type: 'bytes32[]', name: 'intentIds' },
-    { type: 'uint256', name: 'tokenFee' },
-    { type: 'uint256', name: 'nativeFee' }
-  ]
-}] as const;
+const orderCreatedAbi = [
+  {
+    type: 'event',
+    name: 'OrderCreated',
+    inputs: [
+      { indexed: true, type: 'bytes32', name: 'orderId' },
+      { indexed: true, type: 'address', name: 'initiator' },
+      { type: 'bytes32[]', name: 'intentIds' },
+      { type: 'uint256', name: 'tokenFee' },
+      { type: 'uint256', name: 'nativeFee' },
+    ],
+  },
+] as const;
 
 /**
  * Uses the api to get the tx data and chainservice to send intents and approve assets if required.
@@ -187,14 +189,16 @@ export const sendIntents = async (
         chainId: intents[0].origin,
         logs: newOrderTx.logs,
       });
-      
+
       // Tx was successful but logs weren't fetched correctly - use the tx hash
       // as the intentId so the process can continue
-      return [{
-        transactionHash: newOrderTx.transactionHash,
-        chainId: intents[0].origin,
-        intentId: newOrderTx.transactionHash,
-      }];
+      return [
+        {
+          transactionHash: newOrderTx.transactionHash,
+          chainId: intents[0].origin,
+          intentId: newOrderTx.transactionHash,
+        },
+      ];
     }
 
     const { args } = decodeEventLog({

--- a/packages/poller/src/helpers/intent.ts
+++ b/packages/poller/src/helpers/intent.ts
@@ -1,5 +1,4 @@
 import { MarkConfiguration, NewIntentParams } from '@mark/core';
-import { ProcessInvoicesDependencies } from '../invoice/pollAndProcess';
 import { getERC20Contract } from './contracts';
 import { encodeFunctionData, erc20Abi } from 'viem';
 import { TransactionReason } from '@mark/prometheus';
@@ -11,6 +10,7 @@ import {
   getPermit2Address,
 } from './permit2';
 import { prepareMulticall } from './multicall';
+import { MarkAdapters } from '../init';
 
 export const INTENT_ADDED_TOPIC0 = '0xefe68281645929e2db845c5b42e12f7c73485fb5f18737b7b29379da006fa5f7';
 
@@ -20,11 +20,11 @@ export const INTENT_ADDED_TOPIC0 = '0xefe68281645929e2db845c5b42e12f7c73485fb5f1
 export const sendIntents = async (
   invoiceId: string,
   intents: NewIntentParams[],
-  deps: ProcessInvoicesDependencies,
+  adapters: MarkAdapters,
   config: MarkConfiguration,
   requestId?: string,
 ): Promise<{ transactionHash: string; chainId: string; intentId: string }[]> => {
-  const { everclear, chainService, prometheus, logger } = deps;
+  const { everclear, chainService, prometheus, logger } = adapters;
 
   if (!intents.length) {
     logger.info('No intents to process', { invoiceId });
@@ -206,14 +206,14 @@ export const sendIntents = async (
  */
 export const sendIntentsMulticall = async (
   intents: NewIntentParams[],
-  deps: ProcessInvoicesDependencies,
+  adapters: MarkAdapters,
   config: MarkConfiguration,
 ): Promise<{ transactionHash: string; chainId: string; intentId: string }> => {
   if (!intents || intents.length === 0) {
     throw new Error('No intents provided for multicall');
   }
 
-  const { chainService, everclear, logger, prometheus, web3Signer } = deps;
+  const { chainService, everclear, logger, prometheus, web3Signer } = adapters;
 
   const txs = [];
 

--- a/packages/poller/src/helpers/splitIntent.ts
+++ b/packages/poller/src/helpers/splitIntent.ts
@@ -93,6 +93,10 @@ export async function calculateSplitIntents(
   logger.info('Got supported domains to evaluate', {
     requestId,
     invoiceId: invoice.intent_id,
+    assetSupportedDomains,
+    minAmounts,
+    balances: jsonifyMap(balances),
+    custodiedAssets: jsonifyMap(custodiedAssets),
   });
 
   // Sort the top-N domains by custodied assets

--- a/packages/poller/src/helpers/splitIntent.ts
+++ b/packages/poller/src/helpers/splitIntent.ts
@@ -277,7 +277,7 @@ export async function calculateSplitIntents(
   const remainder = totalNeeded - bestAllocation.totalAllocated;
   if (remainder > BigInt(0)) {
     // Dumb split: create top-N intents to split remainder evenly across top-N chains
-    const validTopNDomains = topNDomainsFromConfig.filter(domain => domain !== bestAllocation.origin);
+    const validTopNDomains = topNDomainsFromConfig.filter((domain) => domain !== bestAllocation.origin);
     const splitAmount = remainder / BigInt(validTopNDomains.length);
     const params: NewIntentParams = {
       origin: bestAllocation.origin,
@@ -292,7 +292,10 @@ export async function calculateSplitIntents(
 
     // Last one topped up with remainder of remainder
     const dust = remainder % BigInt(validTopNDomains.length);
-    const lastParams = { ...params, amount: convertHubAmountToLocalDecimals(splitAmount + dust, inputAsset, bestAllocation.origin, config).toString() };
+    const lastParams = {
+      ...params,
+      amount: convertHubAmountToLocalDecimals(splitAmount + dust, inputAsset, bestAllocation.origin, config).toString(),
+    };
     intents.push(lastParams);
 
     logger.info('Added remainder intents to allocation', {

--- a/packages/poller/src/helpers/splitIntent.ts
+++ b/packages/poller/src/helpers/splitIntent.ts
@@ -1,7 +1,8 @@
-import { getTokenAddressFromConfig, Invoice, MarkConfiguration, NewIntentParams } from '@mark/core';
-import { jsonifyMap, Logger } from '@mark/logger';
+import { getTokenAddressFromConfig, Invoice, NewIntentParams } from '@mark/core';
+import { jsonifyMap } from '@mark/logger';
 import { convertHubAmountToLocalDecimals } from './asset';
 import { MAX_DESTINATIONS, TOP_N_DESTINATIONS } from '../invoice/processInvoices';
+import { ProcessingContext } from '../init';
 
 interface SplitIntentAllocation {
   origin: string;
@@ -70,14 +71,13 @@ function evaluateDomainForOrigin(
  * Calculates split intents for an invoice
  */
 export async function calculateSplitIntents(
+  context: ProcessingContext,
   invoice: Invoice,
   minAmounts: Record<string, string>,
-  config: MarkConfiguration,
   balances: Map<string, Map<string, bigint>>,
   custodiedAssets: Map<string, Map<string, bigint>>,
-  logger: Logger,
-  requestId?: string,
 ): Promise<SplitIntentResult> {
+  const { config, logger, requestId } = context;
   const ticker = invoice.ticker_hash;
   const allCustodiedAssets = custodiedAssets.get(ticker) || new Map<string, bigint>();
   const configDomains = config.supportedSettlementDomains.map((d) => d.toString());

--- a/packages/poller/src/init.ts
+++ b/packages/poller/src/init.ts
@@ -21,7 +21,7 @@ export interface ProcessingContext extends MarkAdapters {
   config: MarkConfiguration;
   requestId: string;
   startTime: number;
-} 
+}
 
 function initializeAdapters(config: MarkConfiguration, logger: Logger): MarkAdapters {
   // Initialize adapters in the correct order

--- a/packages/poller/src/init.ts
+++ b/packages/poller/src/init.ts
@@ -7,6 +7,7 @@ import { Wallet } from 'ethers';
 import { pollAndProcess } from './invoice';
 import { PurchaseCache } from '@mark/cache';
 import { PrometheusAdapter } from '@mark/prometheus';
+import { hexlify, randomBytes } from 'ethers/lib/utils';
 
 export interface MarkAdapters {
   cache: PurchaseCache;
@@ -16,6 +17,11 @@ export interface MarkAdapters {
   logger: Logger;
   prometheus: PrometheusAdapter;
 }
+export interface ProcessingContext extends MarkAdapters {
+  config: MarkConfiguration;
+  requestId: string;
+  startTime: number;
+} 
 
 function initializeAdapters(config: MarkConfiguration, logger: Logger): MarkAdapters {
   // Initialize adapters in the correct order
@@ -69,10 +75,14 @@ export const initPoller = async (): Promise<{ statusCode: number; body: string }
       environment: config.environment,
     });
 
-    const result = await pollAndProcess(config, {
+    const context: ProcessingContext = {
       ...adapters,
-      logger,
-    });
+      config,
+      requestId: hexlify(randomBytes(32)),
+      startTime: Math.floor(Date.now() / 1000),
+    };
+
+    const result = await pollAndProcess(context);
 
     return {
       statusCode: 200,

--- a/packages/poller/src/invoice/pollAndProcess.ts
+++ b/packages/poller/src/invoice/pollAndProcess.ts
@@ -1,9 +1,7 @@
 import { processInvoices } from './processInvoices';
 import { ProcessingContext } from '../init';
 
-export async function pollAndProcess(
-  context: ProcessingContext,
-): Promise<void> {
+export async function pollAndProcess(context: ProcessingContext): Promise<void> {
   const { config, everclear, logger, requestId } = context;
 
   try {
@@ -17,11 +15,11 @@ export async function pollAndProcess(
     await processInvoices(context, invoices);
   } catch (_error: unknown) {
     const error = _error as Error;
-    logger.error('Failed to process invoices', { 
+    logger.error('Failed to process invoices', {
       requestId,
-      message: error.message, 
-      stack: error.stack, 
-      name: error.name 
+      message: error.message,
+      stack: error.stack,
+      name: error.name,
     });
     throw error;
   }

--- a/packages/poller/src/invoice/pollAndProcess.ts
+++ b/packages/poller/src/invoice/pollAndProcess.ts
@@ -1,40 +1,28 @@
-import { PrometheusAdapter } from '@mark/prometheus';
-import { MarkConfiguration } from '@mark/core';
-import { ChainService } from '@mark/chainservice';
-import { EverclearAdapter } from '@mark/everclear';
-import { Logger } from '@mark/logger';
 import { processInvoices } from './processInvoices';
-import { PurchaseCache } from '@mark/cache';
-import { Web3Signer } from '@mark/web3signer';
-import { Wallet } from 'ethers';
+import { ProcessingContext } from '../init';
 
-export interface ProcessInvoicesDependencies {
-  everclear: EverclearAdapter;
-  chainService: ChainService;
-  logger: Logger;
-  cache: PurchaseCache;
-  prometheus: PrometheusAdapter;
-  web3Signer: Web3Signer | Wallet;
-}
-
-export async function pollAndProcess(config: MarkConfiguration, deps: ProcessInvoicesDependencies): Promise<void> {
-  const { everclear, logger, chainService, cache, prometheus, web3Signer } = deps;
+export async function pollAndProcess(
+  context: ProcessingContext,
+): Promise<void> {
+  const { config, everclear, logger, requestId } = context;
 
   try {
     const invoices = await everclear.fetchInvoices(config.chains);
-    await processInvoices({
-      invoices,
-      everclear,
-      logger,
-      chainService,
-      cache,
-      prometheus,
-      config,
-      web3Signer,
-    });
+
+    if (invoices.length === 0) {
+      logger.info('No invoices to process', { requestId });
+      return;
+    }
+
+    await processInvoices(context, invoices);
   } catch (_error: unknown) {
     const error = _error as Error;
-    logger.error('Failed to process invoices', { message: error.message, stack: error.stack, name: error.name });
+    logger.error('Failed to process invoices', { 
+      requestId,
+      message: error.message, 
+      stack: error.stack, 
+      name: error.name 
+    });
     throw error;
   }
 }

--- a/packages/poller/src/invoice/pollAndProcess.ts
+++ b/packages/poller/src/invoice/pollAndProcess.ts
@@ -1,5 +1,6 @@
 import { processInvoices } from './processInvoices';
 import { ProcessingContext } from '../init';
+import { jsonifyError } from '@mark/logger';
 
 export async function pollAndProcess(context: ProcessingContext): Promise<void> {
   const { config, everclear, logger, requestId } = context;
@@ -15,12 +16,7 @@ export async function pollAndProcess(context: ProcessingContext): Promise<void> 
     await processInvoices(context, invoices);
   } catch (_error: unknown) {
     const error = _error as Error;
-    logger.error('Failed to process invoices', {
-      requestId,
-      message: error.message,
-      stack: error.stack,
-      name: error.name,
-    });
+    logger.error('Failed to process invoices', { error: jsonifyError(error, { requestId }) });
     throw error;
   }
 }

--- a/packages/poller/src/invoice/processInvoices.ts
+++ b/packages/poller/src/invoice/processInvoices.ts
@@ -1,9 +1,8 @@
-import { InvalidPurchaseReasons, Invoice, MarkConfiguration } from '@mark/core';
-import { PurchaseCache } from '@mark/cache';
-import { jsonifyError, jsonifyMap, Logger } from '@mark/logger';
-import { EverclearAdapter, IntentStatus } from '@mark/everclear';
-import { hexlify, randomBytes } from 'ethers/lib/utils';
-import { InvoiceLabels, PrometheusAdapter } from '@mark/prometheus';
+import { InvalidPurchaseReasons, Invoice, NewIntentParams } from '@mark/core';
+import { jsonifyError, jsonifyMap } from '@mark/logger';
+import { IntentStatus } from '@mark/everclear';
+import { InvoiceLabels } from '@mark/prometheus';
+import { ProcessingContext } from '../init';
 import {
   getMarkBalances,
   getMarkGasBalances,
@@ -14,75 +13,346 @@ import {
   getCustodiedBalances,
 } from '../helpers';
 import { isValidInvoice } from './validation';
-import { ChainService } from '@mark/chainservice';
-import { Web3Signer } from '@mark/web3signer';
-import { Wallet } from 'ethers';
-
-interface ProcessInvoicesParams {
-  invoices: Invoice[];
-  cache: PurchaseCache;
-  logger: Logger;
-  everclear: EverclearAdapter;
-  chainService: ChainService;
-  prometheus: PrometheusAdapter;
-  config: MarkConfiguration;
-  web3Signer: Web3Signer | Wallet;
-}
+import { PurchaseAction } from '@mark/cache';
 
 export const MAX_DESTINATIONS = 10; // enforced onchain at 10
 export const TOP_N_DESTINATIONS = 7; // mark's preferred top-N domains ordered in his config
 
 const getTimeSeconds = () => Math.floor(Date.now() / 1000);
 
-export async function processInvoices({
-  invoices,
-  everclear,
-  cache,
-  chainService,
-  logger,
-  prometheus,
-  config,
-  web3Signer,
-}: ProcessInvoicesParams): Promise<void> {
-  // Create request id tracker for polling
-  const requestId = hexlify(randomBytes(32));
+export interface TickerGroup {
+  ticker: string;
+  invoices: Invoice[];
+  remainingBalances: Map<string, Map<string, bigint>>;
+  remainingCustodied: Map<string, Map<string, bigint>>;
+  chosenOrigin: string | null;
+  batchedInvoices: Invoice[];
+  batchedIntents: NewIntentParams[];
+}
 
-  // Get current time to measure invoice age
-  const time = getTimeSeconds();
-  let start = time;
-  logger.debug('Method start', { requestId, start });
+/**
+ * Groups invoices by ticker hash
+ * @param context - The processing context
+ * @param invoices - The invoices to group
+ * @returns A map of ticker hash to invoices, sorted by oldest first
+ */
+export function groupInvoicesByTicker(
+  context: ProcessingContext,
+  invoices: Invoice[]
+): Map<string, Invoice[]> {
+  const { prometheus } = context;
 
+  const invoiceQueues = new Map<string, Invoice[]>();
+  
+  invoices
+    .sort((a, b) => a.hub_invoice_enqueued_timestamp - b.hub_invoice_enqueued_timestamp)
+    .forEach((invoice) => {
+      if (!invoiceQueues.has(invoice.ticker_hash)) {
+        invoiceQueues.set(invoice.ticker_hash, []);
+      }
+      invoiceQueues.get(invoice.ticker_hash)!.push(invoice);
+
+      // Record invoice as seen
+      const labels: InvoiceLabels = { 
+        origin: invoice.origin, 
+        id: invoice.intent_id, 
+        ticker: invoice.ticker_hash 
+      };
+      prometheus.recordPossibleInvoice(labels);
+    });
+
+  return invoiceQueues;
+}
+
+/**
+ * Processes a group of invoices grouped by ticker hash
+ * @param context - The processing context
+ * @param group - The ticker group to process
+ * @param pendingPurchases - The pending purchases to check against
+ * @returns The purchase actions that were created
+ */
+export async function processTickerGroup(
+  context: ProcessingContext,
+  group: TickerGroup,
+  pendingPurchases: PurchaseAction[]
+): Promise<{
+  purchases: PurchaseAction[];
+  remainingBalances: Map<string, Map<string, bigint>>;
+  remainingCustodied: Map<string, Map<string, bigint>>;
+}> {
+  const { config, everclear, cache, logger, prometheus, chainService, web3Signer, requestId, startTime } = context;
+  let start = startTime;
+
+  logger.debug('Processing ticker group', { 
+    requestId, 
+    ticker: group.ticker, 
+    invoiceCount: group.invoices.length 
+  });
+
+  const toEvaluate = group.invoices
+    .map((i) => {
+      const reason = isValidInvoice(i, config, start);
+      if (reason) {
+        logger.warn('Invoice is invalid, skipping.', {
+          requestId,
+          invoiceId: i.intent_id,
+          ticker: group.ticker,
+          invoice: i,
+          reason,
+          duration: getTimeSeconds() - start,
+        });
+        prometheus.recordInvalidPurchase(reason, { origin: i.origin, id: i.intent_id, ticker: i.ticker_hash });
+        return undefined;
+      }
+      return i;
+    })
+    .filter((x) => !!x);
+
+  // Track for batching invoice purchases
+  let remainingBalances = new Map(group.remainingBalances);
+  let remainingCustodied = new Map(group.remainingCustodied);
+  let batchedInvoices: Invoice[] = [];
+  let batchedIntents: NewIntentParams[] = [];
+  let chosenOrigin: string | null = null;
+  
+  for (const invoice of toEvaluate) {
+    start = getTimeSeconds();
+    const invoiceId = invoice.intent_id;
+    const labels: InvoiceLabels = { origin: invoice.origin, id: invoice.intent_id, ticker: invoice.ticker_hash };
+
+    // Skip entire ticker group if we already have a purchase for this invoice
+    if (pendingPurchases.find(({ target }) => target.intent_id === invoiceId)) {
+      logger.debug('Found existing purchase, stopping ticker processing', {
+        requestId, ticker: invoice.ticker_hash, invoiceId, invoice, duration: getTimeSeconds() - start,
+      });
+      prometheus.recordInvalidPurchase(InvalidPurchaseReasons.PendingPurchaseRecord, labels);
+      break;
+    }
+
+    // Skip this invoice if XERC20 is supported
+    if (await isXerc20Supported(invoice.ticker_hash, invoice.destinations, config)) {
+      logger.info('XERC20 strategy enabled for invoice destination, skipping', {
+        requestId, invoiceId, destinations: invoice.destinations, invoice, ticker: invoice.ticker_hash,
+        duration: getTimeSeconds() - start,
+      });
+      prometheus.recordInvalidPurchase(InvalidPurchaseReasons.DestinationXerc20, labels);
+      continue;
+    }
+
+    // Get the minimum amounts for invoice
+    const minAmounts = await (async () => {
+      try {
+        const { minAmounts: _minAmounts } = await everclear.getMinAmounts(invoiceId);
+        logger.debug('Got minimum amounts for invoice', {
+          requestId, invoiceId, invoice, minAmounts: _minAmounts, duration: getTimeSeconds() - start,
+        });
+        return _minAmounts;
+      } catch (e) {
+        logger.error('Failed to get min amounts for invoice', {
+          requestId, invoiceId, invoice, error: jsonifyError(e), duration: getTimeSeconds() - start,
+        });
+        return Object.fromEntries(invoice.destinations.map((d) => [d, '0']));
+      }
+    })();
+
+    // Set for ticker-destination pair lookup
+    const existingDestinations = new Set(
+      pendingPurchases.filter((p) => p.target.ticker_hash === invoice.ticker_hash).map((p) => p.purchase.params.origin),
+    );
+
+    // Filter out origins that already have pending purchases for this destination-ticker combo
+    let filteredMinAmounts = Object.fromEntries(
+      Object.entries(minAmounts).filter(([destination]) => {
+        if (existingDestinations.has(destination)) {
+          logger.info('Action exists for destination-ticker combo, removing from consideration', {
+            requestId, invoiceId, destination, duration: getTimeSeconds() - start,
+          });
+          prometheus.recordInvalidPurchase(InvalidPurchaseReasons.PendingPurchaseRecord, { ...labels, destination });
+          return false;
+        }
+        return true;
+      })
+    );
+
+    // Skip if no valid origins remain
+    if (Object.keys(filteredMinAmounts).length === 0) {
+      logger.info('No valid origins remain after filtering existing purchases', {
+        requestId, invoiceId, duration: getTimeSeconds() - start,
+      });
+      continue;
+    }
+
+    // Use all candidate origins in split calc for the first invoice of this ticker.
+    // For subsequent invoices, only use the chosen origin.
+    filteredMinAmounts = chosenOrigin ? 
+      { [chosenOrigin]: filteredMinAmounts[chosenOrigin] || '0' } : 
+      filteredMinAmounts;
+
+    const { intents, originDomain } = await calculateSplitIntents(
+      invoice,
+      filteredMinAmounts,
+      config,
+      remainingBalances,
+      remainingCustodied,
+      logger,
+      requestId,
+    );
+
+    // Oldest invoice, prio enabled, and couldn't find a valid allocation
+    if (!originDomain && batchedInvoices.length === 0 && config.prioritizeOldestInvoice) {
+      logger.info('Cannot settle oldest invoice in ticker group with prioritization enabled, skipping group', {
+        requestId, invoiceId, ticker: invoice.ticker_hash, duration: getTimeSeconds() - start,
+      });
+      break;
+    }
+
+    if (intents.length > 0) {
+      // First purchase of the ticker group, use this origin for subsequent invoices
+      if (!chosenOrigin) {
+        chosenOrigin = originDomain;
+        logger.info('Selected origin for ticker group', { requestId, ticker: invoice.ticker_hash, origin: chosenOrigin });
+      }
+
+      batchedInvoices.push(invoice);
+      batchedIntents.push(...intents);
+
+      // Update remaining balance for the chosen origin
+      const currentBalance = remainingBalances.get(invoice.ticker_hash)?.get(originDomain) || BigInt('0');
+      const requiredAmount = BigInt(minAmounts[originDomain]);
+      remainingBalances.get(invoice.ticker_hash)?.set(originDomain, currentBalance - requiredAmount);
+
+      // Update remaining custodied for the target destination
+      // First dest is the actual target of the intent (we pad the others for backup)
+      const targetDestination = intents[0].destinations[0];
+      const currentCustodied = remainingCustodied.get(invoice.ticker_hash)?.get(targetDestination) || BigInt('0');
+      const totalAllocated = intents.reduce((sum, intent) => sum + BigInt(intent.amount), BigInt('0'));
+      remainingCustodied.get(invoice.ticker_hash)?.set(targetDestination, currentCustodied - totalAllocated);
+
+      logger.info('Added invoice to batch', {
+        requestId, invoiceId, origin: originDomain, targetDestination, totalAllocated: totalAllocated.toString(),
+        intentCount: intents.length, duration: getTimeSeconds() - start,
+      });
+    }
+  }
+
+  // Send all batched intents for this ticker group
+  if (batchedInvoices.length > 0 && batchedIntents.length > 0) {
+    try {
+      const intentResults = await sendIntents(
+        batchedInvoices[0].intent_id,
+        batchedIntents,
+        { everclear, logger, cache, prometheus, chainService, web3Signer },
+        config,
+        requestId
+      );
+
+      // Record metrics for all batched invoices
+      batchedInvoices.forEach(batchedInvoice => {
+        prometheus.recordSuccessfulPurchase({
+          origin: batchedInvoice.origin,
+          id: batchedInvoice.intent_id,
+          ticker: batchedInvoice.ticker_hash,
+          destination: batchedIntents[0].origin,
+          isSplit: batchedIntents.length > 1 ? 'true' : 'false',
+          splitCount: batchedIntents.length.toString(),
+        });
+        prometheus.recordInvoicePurchaseDuration(
+          Math.floor(Date.now()) - batchedInvoice.hub_invoice_enqueued_timestamp
+        );
+      });
+
+      logger.info(`Created purchases for batched invoices`, {
+        requestId,
+        batchedInvoiceIds: batchedInvoices.map(inv => inv.intent_id),
+        allIntentResults: intentResults.map((result, index) => ({
+          intentIndex: index,
+          intentId: result.intentId,
+          transactionHash: result.transactionHash,
+          params: batchedIntents[index],
+        })),
+        intentCount: batchedIntents.length,
+        transactionHashes: intentResults.map((result) => result.transactionHash),
+        duration: getTimeSeconds() - start,
+      });
+
+      // Return the actual purchases with real intent IDs and transaction hashes
+      return {
+        purchases: batchedInvoices.flatMap(batchedInvoice => 
+          intentResults.map((result, i) => ({
+            target: batchedInvoice,
+            purchase: {
+              intentId: result.intentId,
+              params: batchedIntents[i],
+            },
+            transactionHash: result.transactionHash,
+            batchedWith: batchedInvoices
+              .map(inv => inv.intent_id)
+              .filter(id => id !== batchedInvoice.intent_id),
+          }))
+        ),
+        remainingBalances,
+        remainingCustodied,
+      };
+    } catch (error) {
+      prometheus.recordInvalidPurchase(InvalidPurchaseReasons.TransactionFailed, {
+        origin: batchedInvoices[0].origin,
+        id: batchedInvoices[0].intent_id,
+        ticker: batchedInvoices[0].ticker_hash,
+        destination: batchedIntents[0].origin,
+      });
+      logger.error(`Failed to submit purchase transaction(s) for batch`, {
+        error: jsonifyError(error),
+        batchedInvoiceIds: batchedInvoices.map(inv => inv.intent_id),
+        intentCount: batchedIntents.length,
+        duration: getTimeSeconds() - start,
+      });
+      throw error;
+    }
+  }
+
+  return {
+    purchases: [],
+    remainingBalances,
+    remainingCustodied,
+  };
+}
+
+/**
+ * Processes given invoices against Mark's balances and custodied assets
+ * @param context - The processing context
+ * @param invoices - The invoices to process
+ */
+export async function processInvoices(
+  context: ProcessingContext,
+  invoices: Invoice[]
+): Promise<void> {
+  const { config, everclear, cache, logger, prometheus, chainService, web3Signer, requestId, startTime } = context;
+  let start = startTime;
+  
   logger.info('Starting invoice processing', {
     requestId,
     invoiceCount: invoices.length,
     invoices: invoices.map((i) => i.intent_id),
   });
 
-  // Query all of marks balances across chains
+  // Query all of Mark's balances across chains
   logger.info('Getting mark balances', { requestId, chains: Object.keys(config.chains) });
+  start = getTimeSeconds();
   const balances = await getMarkBalances(config, prometheus);
   logger.debug('Retrieved balances', { requestId, balances: jsonifyMap(balances), duration: getTimeSeconds() - start });
 
-  // Query all of marks gas balances across chains
+  // Query all of Mark's gas balances across chains
   logger.info('Getting mark gas balances', { requestId, chains: Object.keys(config.chains) });
   start = getTimeSeconds();
   const gasBalances = await getMarkGasBalances(config, prometheus);
   logGasThresholds(gasBalances, config, logger);
-  logger.debug('Retrieved gas balances', {
-    requestId,
-    gasBalances: jsonifyMap(gasBalances),
-    duration: getTimeSeconds() - start,
-  });
+  logger.debug('Retrieved gas balances', { requestId, gasBalances: jsonifyMap(gasBalances), duration: getTimeSeconds() - start });
 
   // Get all custodied assets
   logger.info('Getting custodied assets', { requestId, chains: Object.keys(config.chains) });
   start = getTimeSeconds();
   const custodiedAssets = await getCustodiedBalances(config);
-  logger.debug('Retrieved custodied assets', {
-    requestId,
-    custodiedAssets: jsonifyMap(custodiedAssets),
-    duration: getTimeSeconds() - start,
-  });
+  logger.debug('Retrieved custodied assets', { requestId, custodiedAssets: jsonifyMap(custodiedAssets), duration: getTimeSeconds() - start });
 
   // Get existing purchase actions
   logger.debug('Getting cached purchases', { requestId });
@@ -94,7 +364,7 @@ export async function processInvoices({
   // Remove cached purchases that no longer apply to an invoice.
   const targetsToRemove = (
     await Promise.all(
-      cachedPurchases.map(async (purchase) => {
+      cachedPurchases.map(async (purchase: PurchaseAction) => {
         // Remove purchases that are invoiced or settled
         const status = await everclear.intentStatus(purchase.purchase.intentId);
         const spentStatuses = [
@@ -116,7 +386,7 @@ export async function processInvoices({
     )
   ).filter((x: string | undefined) => !!x);
 
-  const pendingPurchases = cachedPurchases.filter(({ target }) => !targetsToRemove.includes(target.intent_id));
+  const pendingPurchases = cachedPurchases.filter(({ target }: PurchaseAction) => !targetsToRemove.includes(target.intent_id));
 
   try {
     await cache.removePurchases(targetsToRemove as string[]);
@@ -130,263 +400,48 @@ export async function processInvoices({
     logger.warn('Failed to clear pending cache', { requestId, error: jsonifyError(e, { targetsToRemove }) });
   }
 
-  // Group invoices by ticker
-  const invoiceQueues = new Map<string, Invoice[]>(); // [tickerHash]: invoice[] (oldest first)
-  invoices
-    .sort((a, b) => a.hub_invoice_enqueued_timestamp - b.hub_invoice_enqueued_timestamp)
-    .forEach((invoice) => {
-      if (!invoiceQueues.has(invoice.ticker_hash)) {
-        invoiceQueues.set(invoice.ticker_hash, []);
-      }
-      invoiceQueues.get(invoice.ticker_hash)!.push(invoice);
-
-      // Record invoice as seen
-      const labels: InvoiceLabels = {
-        origin: invoice.origin,
-        id: invoice.intent_id,
-        ticker: invoice.ticker_hash,
-      };
-      prometheus.recordPossibleInvoice(labels);
-    });
-
-  // Process each ticker group. Goal is to process the first (earliest) invoice in each queue.
-  start = getTimeSeconds();
+  const invoiceQueues = groupInvoicesByTicker(context, invoices);
+  let remainingBalances = new Map(balances);
+  let remainingCustodied = new Map(custodiedAssets);
+  const allPurchases: PurchaseAction[] = [];
+  
+  // Process each ticker group
   for (const [ticker, invoiceQueue] of invoiceQueues.entries()) {
-    logger.debug('Processing ticker group', { requestId, ticker, invoiceCount: invoiceQueue.length });
-    const toEvaluate = invoiceQueue
-      .map((i) => {
-        const reason = isValidInvoice(i, config, time);
-        if (reason) {
-          logger.warn('Invoice is invalid, skipping.', {
-            requestId,
-            invoiceId: i.intent_id,
-            ticker,
-            invoice: i,
-            reason,
-            duration: getTimeSeconds() - start,
-          });
-          prometheus.recordInvalidPurchase(reason, { origin: i.origin, id: i.intent_id, ticker: i.ticker_hash });
-          return undefined;
-        }
-        return i;
-      })
-      .filter((x) => !!x);
+    const group: TickerGroup = {
+      ticker,
+      invoices: invoiceQueue,
+      remainingBalances,
+      remainingCustodied,
+      chosenOrigin: null,
+      batchedInvoices: [],
+      batchedIntents: [],
+    };
 
-    // Process invoices until we find one we've already purchased
-    for (const invoice of toEvaluate) {
-      start = getTimeSeconds();
-      const invoiceId = invoice.intent_id;
-      const labels: InvoiceLabels = {
-        origin: invoice.origin,
-        id: invoice.intent_id,
-        ticker,
-      };
+    try {
+      const { purchases, remainingBalances: newBalances, remainingCustodied: newCustodied } = 
+        await processTickerGroup(context, group, pendingPurchases);
 
-      // Skip entire ticker if we already have a purchase for this invoice
-      if (pendingPurchases.find(({ target }) => target.intent_id === invoiceId)) {
-        logger.debug('Found existing purchase, stopping ticker processing', {
-          requestId,
-          ticker,
-          invoiceId,
-          invoice,
-          duration: getTimeSeconds() - start,
-        });
-        prometheus.recordInvalidPurchase(InvalidPurchaseReasons.PendingPurchaseRecord, labels);
-        break;
-      }
-
-      // Add XERC20 check here
-      const isXerc20 = await isXerc20Supported(invoice.ticker_hash, invoice.destinations, config);
-      if (isXerc20) {
-        logger.info('XERC20 strategy enabled for invoice destination, skipping', {
-          requestId,
-          invoiceId,
-          destinations: invoice.destinations,
-          invoice,
-          ticker,
-          duration: getTimeSeconds() - start,
-        });
-        prometheus.recordInvalidPurchase(InvalidPurchaseReasons.DestinationXerc20, labels);
-        continue;
-      }
-
-      // Get the minimum amounts for invoice
-      let minAmounts: Record<string, string>;
-      try {
-        const { minAmounts: _minAmounts } = await everclear.getMinAmounts(invoiceId);
-        minAmounts = _minAmounts;
-        logger.debug('Got minimum amounts for invoice', {
-          requestId,
-          invoiceId,
-          invoice,
-          minAmounts,
-          duration: getTimeSeconds() - start,
-        });
-      } catch (e) {
-        logger.error('Failed to get min amounts for invoice', {
-          requestId,
-          invoiceId,
-          invoice,
-          error: jsonifyError(e),
-          duration: getTimeSeconds() - start,
-        });
-        minAmounts = Object.fromEntries(invoice.destinations.map((d) => [d, '0']));
-      }
-
-      // Set for ticker-destination pair lookup
-      const existingDestinations = new Set(
-        pendingPurchases.filter((p) => p.target.ticker_hash === ticker).map((p) => p.purchase.params.origin),
-      );
-
-      // Filter out origins that already have pending purchases for this destination-ticker combo
-      const filteredMinAmounts = { ...minAmounts };
-      for (const destination of Object.keys(filteredMinAmounts)) {
-        if (existingDestinations.has(destination)) {
-          logger.info('Action exists for destination-ticker combo, removing from consideration', {
-            requestId,
-            invoiceId,
-            destination,
-            duration: getTimeSeconds() - start,
-          });
-          prometheus.recordInvalidPurchase(InvalidPurchaseReasons.PendingPurchaseRecord, {
-            ...labels,
-            destination,
-          });
-          delete filteredMinAmounts[destination];
-        }
-      }
-
-      // Skip if no valid origins remain
-      if (Object.keys(filteredMinAmounts).length === 0) {
-        logger.info('No valid origins remain after filtering existing purchases', {
-          requestId,
-          invoiceId,
-          duration: getTimeSeconds() - start,
-        });
-        continue;
-      }
-
-      // Calculate optimal intents to fire using split intents calc
-      const { intents, originDomain, totalAllocated } = await calculateSplitIntents(
-        invoice,
-        filteredMinAmounts,
-        config,
-        balances,
-        custodiedAssets,
-        logger,
-        requestId,
-      );
-      logger.info('Calculated split intents for invoice', {
-        requestId,
-        invoiceId,
-        intents,
-        origin: originDomain,
-        totalAllocated,
-      });
-
-      if (intents.length === 0) {
-        logger.info('No valid intents can be generated for invoice', {
-          requestId,
-          invoiceId,
-          minAmounts,
-          duration: getTimeSeconds() - start,
-        });
-        // Record insufficient balance as the reason since calculateSplitIntents returned no intents
-        prometheus.recordInvalidPurchase(InvalidPurchaseReasons.InsufficientBalance, labels);
-        // Skip to next invoice
-        continue;
-      }
-
-      try {
-        const intentResults = await sendIntents(
-          invoiceId,
-          intents,
-          { everclear, chainService, logger, cache, prometheus, web3Signer },
-          config,
-          requestId,
-        );
-
-        // Store all purchases in pendingPurchases
-        for (let i = 0; i < intentResults.length; i++) {
-          const purchase = {
-            target: invoice,
-            purchase: {
-              intentId: intentResults[i].intentId,
-              params: intents[i],
-            },
-            transactionHash: intentResults[i].transactionHash,
-          };
-          pendingPurchases.push(purchase);
-        }
-
-        // Record metrics
-        prometheus.recordSuccessfulPurchase({
-          ...labels,
-          destination: originDomain,
-          isSplit: intents.length > 1 ? 'true' : 'false',
-          splitCount: intents.length.toString(),
-        });
-        prometheus.recordInvoicePurchaseDuration(Math.floor(Date.now()) - invoice.hub_invoice_enqueued_timestamp);
-
-        // Log all intent results together with the invoice ID
-        logger.info(`Created purchases for invoice`, {
-          requestId,
-          invoiceId: invoice.intent_id,
-          allIntentResults: intentResults.map((result, index) => ({
-            intentIndex: index,
-            intentId: result.intentId,
-            transactionHash: result.transactionHash,
-            params: intents[index],
-          })),
-          totalAmount: invoice.amount,
-          totalAllocated: totalAllocated.toString(),
-          intentCount: intents.length,
-          coverage: `${Number((BigInt(totalAllocated) * BigInt(100)) / BigInt(invoice.amount)).toFixed(2)}%`,
-          transactionHashes: intentResults.map((result) => result.transactionHash),
-          duration: getTimeSeconds() - start,
-        });
-      } catch (error) {
-        prometheus.recordInvalidPurchase(InvalidPurchaseReasons.TransactionFailed, {
-          ...labels,
-          destination: originDomain,
-        });
-        logger.error(`Failed to submit purchase transaction('s')}`, {
-          error: jsonifyError(error),
-          invoiceId: invoice.intent_id,
-          intentCount: intents.length,
-          originDomain,
-          duration: getTimeSeconds() - start,
-        });
-
-        // Continue to next invoice if this one failed
-        continue;
-      }
+      remainingBalances = newBalances;
+      remainingCustodied = newCustodied;
+      allPurchases.push(...purchases);
+    } catch (error) {
+      logger.error('Failed to process ticker group', { requestId, ticker, error: jsonifyError(error), duration: getTimeSeconds() - start });
+      continue;
     }
   }
 
-  if (pendingPurchases.length === 0) {
-    logger.info('Method complete with 0 purchases', {
-      requestId,
-      pendingPurchases,
-      invoices,
-      duration: getTimeSeconds() - time,
-    });
-    return;
-  }
-
   // Store purchases in cache
-  try {
-    await cache.addPurchases(pendingPurchases);
-    logger.info(`Stored ${pendingPurchases.length} purchases in cache`, { requestId, purchases: pendingPurchases });
-  } catch (e) {
-    logger.error('Failed to add purchases to cache', { requestId, error: jsonifyError(e, { pendingPurchases }) });
-    throw e;
+  if (allPurchases.length > 0) {
+    try {
+      await cache.addPurchases(allPurchases);
+      logger.info(`Stored ${allPurchases.length} purchases in cache`, { requestId, purchases: allPurchases });
+    } catch (e) {
+      logger.error('Failed to add purchases to cache', { requestId, error: jsonifyError(e, { purchases: allPurchases }) });
+      throw e;
+    }
+  } else {
+    logger.info('Method complete with 0 purchases', { requestId, invoices, duration: getTimeSeconds() - startTime });
   }
 
-  logger.info(`Method complete with ${pendingPurchases.length} purchase(s)`, {
-    requestId,
-    pendingPurchases,
-    invoices,
-    duration: getTimeSeconds() - start,
-  });
+  logger.info(`Method complete with ${allPurchases.length} purchase(s)`, { requestId, purchases: allPurchases, invoices, duration: getTimeSeconds() - startTime });
 }

--- a/packages/poller/src/invoice/processInvoices.ts
+++ b/packages/poller/src/invoice/processInvoices.ts
@@ -242,7 +242,7 @@ export async function processTickerGroup(
     });
 
     // Oldest invoice, prio enabled, and couldn't find a valid allocation
-    if (!originDomain && batchedGroup.invoicesWithIntents.length === 0 && config.prioritizeOldestInvoice) {
+    if (!originDomain && batchedGroup.invoicesWithIntents.length === 0 && config.forceOldestInvoice) {
       logger.info('Cannot settle oldest invoice in ticker group with prioritization enabled, skipping group', {
         requestId,
         invoiceId,

--- a/packages/poller/src/invoice/processInvoices.ts
+++ b/packages/poller/src/invoice/processInvoices.ts
@@ -53,14 +53,11 @@ interface BatchedTickerGroup {
  * @param invoices - The invoices to group
  * @returns A map of ticker hash to invoices, sorted by oldest first
  */
-export function groupInvoicesByTicker(
-  context: ProcessingContext,
-  invoices: Invoice[]
-): Map<string, Invoice[]> {
+export function groupInvoicesByTicker(context: ProcessingContext, invoices: Invoice[]): Map<string, Invoice[]> {
   const { prometheus } = context;
 
   const invoiceQueues = new Map<string, Invoice[]>();
-  
+
   invoices
     .sort((a, b) => a.hub_invoice_enqueued_timestamp - b.hub_invoice_enqueued_timestamp)
     .forEach((invoice) => {
@@ -70,10 +67,10 @@ export function groupInvoicesByTicker(
       invoiceQueues.get(invoice.ticker_hash)!.push(invoice);
 
       // Record invoice as seen
-      const labels: InvoiceLabels = { 
-        origin: invoice.origin, 
-        id: invoice.intent_id, 
-        ticker: invoice.ticker_hash 
+      const labels: InvoiceLabels = {
+        origin: invoice.origin,
+        id: invoice.intent_id,
+        ticker: invoice.ticker_hash,
       };
       prometheus.recordPossibleInvoice(labels);
     });
@@ -91,15 +88,15 @@ export function groupInvoicesByTicker(
 export async function processTickerGroup(
   context: ProcessingContext,
   group: TickerGroup,
-  pendingPurchases: PurchaseAction[]
+  pendingPurchases: PurchaseAction[],
 ): Promise<ProcessTickerGroupResult> {
   const { config, everclear, cache, logger, prometheus, chainService, web3Signer, requestId, startTime } = context;
   let start = startTime;
 
-  logger.debug('Processing ticker group', { 
-    requestId, 
-    ticker: group.ticker, 
-    invoiceCount: group.invoices.length 
+  logger.debug('Processing ticker group', {
+    requestId,
+    ticker: group.ticker,
+    invoiceCount: group.invoices.length,
   });
 
   const toEvaluate = group.invoices
@@ -126,13 +123,13 @@ export async function processTickerGroup(
     ticker: group.ticker,
     origin: '',
     invoicesWithIntents: [],
-    totalIntents: 0
+    totalIntents: 0,
   };
 
   // Track remaining balances
   let remainingBalances = new Map(group.remainingBalances);
   let remainingCustodied = new Map(group.remainingCustodied);
-  
+
   for (const invoice of toEvaluate) {
     start = getTimeSeconds();
     const invoiceId = invoice.intent_id;
@@ -141,7 +138,11 @@ export async function processTickerGroup(
     // Skip entire ticker group if we already have a purchase for this invoice
     if (pendingPurchases.find(({ target }) => target.intent_id === invoiceId)) {
       logger.debug('Found existing purchase, stopping ticker processing', {
-        requestId, ticker: invoice.ticker_hash, invoiceId, invoice, duration: getTimeSeconds() - start,
+        requestId,
+        ticker: invoice.ticker_hash,
+        invoiceId,
+        invoice,
+        duration: getTimeSeconds() - start,
       });
       prometheus.recordInvalidPurchase(InvalidPurchaseReasons.PendingPurchaseRecord, labels);
       break;
@@ -150,7 +151,11 @@ export async function processTickerGroup(
     // Skip this invoice if XERC20 is supported
     if (await isXerc20Supported(invoice.ticker_hash, invoice.destinations, config)) {
       logger.info('XERC20 strategy enabled for invoice destination, skipping', {
-        requestId, invoiceId, destinations: invoice.destinations, invoice, ticker: invoice.ticker_hash,
+        requestId,
+        invoiceId,
+        destinations: invoice.destinations,
+        invoice,
+        ticker: invoice.ticker_hash,
         duration: getTimeSeconds() - start,
       });
       prometheus.recordInvalidPurchase(InvalidPurchaseReasons.DestinationXerc20, labels);
@@ -162,12 +167,20 @@ export async function processTickerGroup(
       try {
         const { minAmounts: _minAmounts } = await everclear.getMinAmounts(invoiceId);
         logger.debug('Got minimum amounts for invoice', {
-          requestId, invoiceId, invoice, minAmounts: _minAmounts, duration: getTimeSeconds() - start,
+          requestId,
+          invoiceId,
+          invoice,
+          minAmounts: _minAmounts,
+          duration: getTimeSeconds() - start,
         });
         return _minAmounts;
       } catch (e) {
         logger.error('Failed to get min amounts for invoice', {
-          requestId, invoiceId, invoice, error: jsonifyError(e), duration: getTimeSeconds() - start,
+          requestId,
+          invoiceId,
+          invoice,
+          error: jsonifyError(e),
+          duration: getTimeSeconds() - start,
         });
         return Object.fromEntries(invoice.destinations.map((d) => [d, '0']));
       }
@@ -183,28 +196,33 @@ export async function processTickerGroup(
       Object.entries(minAmounts).filter(([destination]) => {
         if (existingDestinations.has(destination)) {
           logger.info('Action exists for destination-ticker combo, removing from consideration', {
-            requestId, invoiceId, destination, duration: getTimeSeconds() - start,
+            requestId,
+            invoiceId,
+            destination,
+            duration: getTimeSeconds() - start,
           });
           prometheus.recordInvalidPurchase(InvalidPurchaseReasons.PendingPurchaseRecord, { ...labels, destination });
           return false;
         }
         return true;
-      })
+      }),
     );
 
     // Skip if no valid origins remain
     if (Object.keys(filteredMinAmounts).length === 0) {
       logger.info('No valid origins remain after filtering existing purchases', {
-        requestId, invoiceId, duration: getTimeSeconds() - start,
+        requestId,
+        invoiceId,
+        duration: getTimeSeconds() - start,
       });
       continue;
     }
 
     // Use all candidate origins in split calc for the first invoice of this ticker.
     // For subsequent invoices, only use the chosen origin.
-    filteredMinAmounts = batchedGroup.origin ? 
-      { [batchedGroup.origin]: filteredMinAmounts[batchedGroup.origin] || '0' } : 
-      filteredMinAmounts;
+    filteredMinAmounts = batchedGroup.origin
+      ? { [batchedGroup.origin]: filteredMinAmounts[batchedGroup.origin] || '0' }
+      : filteredMinAmounts;
 
     const { intents, originDomain, totalAllocated } = await calculateSplitIntents(
       invoice,
@@ -219,7 +237,10 @@ export async function processTickerGroup(
     // Oldest invoice, prio enabled, and couldn't find a valid allocation
     if (!originDomain && batchedGroup.invoicesWithIntents.length === 0 && config.prioritizeOldestInvoice) {
       logger.info('Cannot settle oldest invoice in ticker group with prioritization enabled, skipping group', {
-        requestId, invoiceId, ticker: invoice.ticker_hash, duration: getTimeSeconds() - start,
+        requestId,
+        invoiceId,
+        ticker: invoice.ticker_hash,
+        duration: getTimeSeconds() - start,
       });
       break;
     }
@@ -228,11 +249,11 @@ export async function processTickerGroup(
       // First purchased invoice in the group sets the origin for all subsequent invoices
       if (!batchedGroup.origin) {
         batchedGroup.origin = originDomain;
-        logger.info('Selected origin for ticker group', { 
-          requestId, 
-          ticker: group.ticker, 
+        logger.info('Selected origin for ticker group', {
+          requestId,
+          ticker: group.ticker,
           origin: batchedGroup.origin,
-          firstInvoiceId: invoiceId
+          firstInvoiceId: invoiceId,
         });
       }
 
@@ -240,7 +261,7 @@ export async function processTickerGroup(
       batchedGroup.invoicesWithIntents.push({
         invoice,
         intents,
-        totalAllocated
+        totalAllocated,
       });
       batchedGroup.totalIntents += intents.length;
 
@@ -278,8 +299,8 @@ export async function processTickerGroup(
   }
 
   // Flatten all intents while maintaining their invoice association
-  const allIntents = batchedGroup.invoicesWithIntents.flatMap(({ invoice, intents }) => 
-    intents.map(intent => ({ params: intent, invoice }))
+  const allIntents = batchedGroup.invoicesWithIntents.flatMap(({ invoice, intents }) =>
+    intents.map((intent) => ({ params: intent, invoice })),
   );
 
   // Send all intents in one batch
@@ -287,10 +308,10 @@ export async function processTickerGroup(
   try {
     const intentResults = await sendIntents(
       allIntents[0].invoice.intent_id,
-      allIntents.map(i => i.params),
+      allIntents.map((i) => i.params),
       { everclear, logger, cache, prometheus, chainService, web3Signer },
       config,
-      requestId
+      requestId,
     );
 
     // Create purchases maintaining the invoice-intent relationship
@@ -313,9 +334,7 @@ export async function processTickerGroup(
         isSplit: intents.length > 1 ? 'true' : 'false',
         splitCount: intents.length.toString(),
       });
-      prometheus.recordInvoicePurchaseDuration(
-        Math.floor(Date.now()) - invoice.hub_invoice_enqueued_timestamp
-      );
+      prometheus.recordInvoicePurchaseDuration(Math.floor(Date.now()) - invoice.hub_invoice_enqueued_timestamp);
     }
 
     logger.info(`Created purchases for batched ticker group`, {
@@ -324,7 +343,7 @@ export async function processTickerGroup(
       origin: batchedGroup.origin,
       invoiceCount: batchedGroup.invoicesWithIntents.length,
       totalIntents: batchedGroup.totalIntents,
-      invoiceIds: batchedGroup.invoicesWithIntents.map(i => i.invoice.intent_id),
+      invoiceIds: batchedGroup.invoicesWithIntents.map((i) => i.invoice.intent_id),
       allIntentResults: intentResults.map((result, index) => ({
         intentIndex: index,
         intentId: result.intentId,
@@ -332,20 +351,17 @@ export async function processTickerGroup(
         invoiceId: allIntents[index].invoice.intent_id,
         params: allIntents[index].params,
       })),
-      transactionHashes: intentResults.map(result => result.transactionHash),
+      transactionHashes: intentResults.map((result) => result.transactionHash),
       duration: getTimeSeconds() - start,
     });
   } catch (error) {
     // Record invalid purchase for each invoice in the batch
     for (const { invoice } of batchedGroup.invoicesWithIntents) {
-      prometheus.recordInvalidPurchase(
-        InvalidPurchaseReasons.TransactionFailed,
-        { 
-          origin: invoice.origin, 
-          id: invoice.intent_id, 
-          ticker: invoice.ticker_hash 
-        }
-      );
+      prometheus.recordInvalidPurchase(InvalidPurchaseReasons.TransactionFailed, {
+        origin: invoice.origin,
+        id: invoice.intent_id,
+        ticker: invoice.ticker_hash,
+      });
     }
 
     logger.error('Failed to send intents for ticker group', {
@@ -353,7 +369,7 @@ export async function processTickerGroup(
       ticker: batchedGroup.ticker,
       origin: batchedGroup.origin,
       invoiceCount: batchedGroup.invoicesWithIntents.length,
-      invoiceIds: batchedGroup.invoicesWithIntents.map(i => i.invoice.intent_id),
+      invoiceIds: batchedGroup.invoicesWithIntents.map((i) => i.invoice.intent_id),
       error: jsonifyError(error),
       duration: getTimeSeconds() - start,
     });
@@ -373,13 +389,10 @@ export async function processTickerGroup(
  * @param context - The processing context
  * @param invoices - The invoices to process
  */
-export async function processInvoices(
-  context: ProcessingContext,
-  invoices: Invoice[]
-): Promise<void> {
+export async function processInvoices(context: ProcessingContext, invoices: Invoice[]): Promise<void> {
   const { config, everclear, cache, logger, prometheus, chainService, web3Signer, requestId, startTime } = context;
   let start = startTime;
-  
+
   logger.info('Starting invoice processing', {
     requestId,
     invoiceCount: invoices.length,
@@ -397,13 +410,21 @@ export async function processInvoices(
   start = getTimeSeconds();
   const gasBalances = await getMarkGasBalances(config, prometheus);
   logGasThresholds(gasBalances, config, logger);
-  logger.debug('Retrieved gas balances', { requestId, gasBalances: jsonifyMap(gasBalances), duration: getTimeSeconds() - start });
+  logger.debug('Retrieved gas balances', {
+    requestId,
+    gasBalances: jsonifyMap(gasBalances),
+    duration: getTimeSeconds() - start,
+  });
 
   // Get all custodied assets
   logger.info('Getting custodied assets', { requestId, chains: Object.keys(config.chains) });
   start = getTimeSeconds();
   const custodiedAssets = await getCustodiedBalances(config);
-  logger.debug('Retrieved custodied assets', { requestId, custodiedAssets: jsonifyMap(custodiedAssets), duration: getTimeSeconds() - start });
+  logger.debug('Retrieved custodied assets', {
+    requestId,
+    custodiedAssets: jsonifyMap(custodiedAssets),
+    duration: getTimeSeconds() - start,
+  });
 
   // Get existing purchase actions
   logger.debug('Getting cached purchases', { requestId });
@@ -437,7 +458,9 @@ export async function processInvoices(
     )
   ).filter((x: string | undefined) => !!x);
 
-  const pendingPurchases = cachedPurchases.filter(({ target }: PurchaseAction) => !targetsToRemove.includes(target.intent_id));
+  const pendingPurchases = cachedPurchases.filter(
+    ({ target }: PurchaseAction) => !targetsToRemove.includes(target.intent_id),
+  );
 
   try {
     await cache.removePurchases(targetsToRemove as string[]);
@@ -455,7 +478,7 @@ export async function processInvoices(
   let remainingBalances = new Map(balances);
   let remainingCustodied = new Map(custodiedAssets);
   const allPurchases: PurchaseAction[] = [];
-  
+
   // Process each ticker group
   for (const [ticker, invoiceQueue] of invoiceQueues.entries()) {
     const group: TickerGroup = {
@@ -467,14 +490,22 @@ export async function processInvoices(
     };
 
     try {
-      const { purchases, remainingBalances: newBalances, remainingCustodied: newCustodied } = 
-        await processTickerGroup(context, group, pendingPurchases);
+      const {
+        purchases,
+        remainingBalances: newBalances,
+        remainingCustodied: newCustodied,
+      } = await processTickerGroup(context, group, pendingPurchases);
 
       remainingBalances = newBalances;
       remainingCustodied = newCustodied;
       allPurchases.push(...purchases);
     } catch (error) {
-      logger.error('Failed to process ticker group', { requestId, ticker, error: jsonifyError(error), duration: getTimeSeconds() - start });
+      logger.error('Failed to process ticker group', {
+        requestId,
+        ticker,
+        error: jsonifyError(error),
+        duration: getTimeSeconds() - start,
+      });
       continue;
     }
   }
@@ -485,12 +516,20 @@ export async function processInvoices(
       await cache.addPurchases(allPurchases);
       logger.info(`Stored ${allPurchases.length} purchases in cache`, { requestId, purchases: allPurchases });
     } catch (e) {
-      logger.error('Failed to add purchases to cache', { requestId, error: jsonifyError(e, { purchases: allPurchases }) });
+      logger.error('Failed to add purchases to cache', {
+        requestId,
+        error: jsonifyError(e, { purchases: allPurchases }),
+      });
       throw e;
     }
   } else {
     logger.info('Method complete with 0 purchases', { requestId, invoices, duration: getTimeSeconds() - startTime });
   }
 
-  logger.info(`Method complete with ${allPurchases.length} purchase(s)`, { requestId, purchases: allPurchases, invoices, duration: getTimeSeconds() - startTime });
+  logger.info(`Method complete with ${allPurchases.length} purchase(s)`, {
+    requestId,
+    purchases: allPurchases,
+    invoices,
+    duration: getTimeSeconds() - startTime,
+  });
 }

--- a/packages/poller/src/invoice/processInvoices.ts
+++ b/packages/poller/src/invoice/processInvoices.ts
@@ -225,13 +225,11 @@ export async function processTickerGroup(
       : filteredMinAmounts;
 
     const { intents, originDomain, totalAllocated } = await calculateSplitIntents(
+      context,
       invoice,
       filteredMinAmounts,
-      config,
       remainingBalances,
       remainingCustodied,
-      logger,
-      requestId,
     );
 
     // Oldest invoice, prio enabled, and couldn't find a valid allocation

--- a/packages/poller/src/invoice/processInvoices.ts
+++ b/packages/poller/src/invoice/processInvoices.ts
@@ -390,7 +390,7 @@ export async function processTickerGroup(
  * @param invoices - The invoices to process
  */
 export async function processInvoices(context: ProcessingContext, invoices: Invoice[]): Promise<void> {
-  const { config, everclear, cache, logger, prometheus, chainService, web3Signer, requestId, startTime } = context;
+  const { config, everclear, cache, logger, prometheus, requestId, startTime } = context;
   let start = startTime;
 
   logger.info('Starting invoice processing', {

--- a/packages/poller/src/invoice/processInvoices.ts
+++ b/packages/poller/src/invoice/processInvoices.ts
@@ -512,7 +512,7 @@ export async function processInvoices(context: ProcessingContext, invoices: Invo
   if (allPurchases.length > 0) {
     try {
       await cache.addPurchases(allPurchases);
-      logger.info(`Stored ${allPurchases.length} purchases in cache`, { requestId, purchases: allPurchases });
+      logger.info(`Stored ${allPurchases.length} purchase(s) in cache`, { requestId, purchases: allPurchases });
     } catch (e) {
       logger.error('Failed to add purchases to cache', {
         requestId,

--- a/packages/poller/test/helpers/intent.spec.ts
+++ b/packages/poller/test/helpers/intent.spec.ts
@@ -17,6 +17,24 @@ import { BigNumber, Wallet } from 'ethers';
 import { PurchaseCache } from '@mark/cache';
 import { PrometheusAdapter } from '@mark/prometheus';
 
+// Common test constants for transaction logs
+const INTENT_ADDED_TOPIC = '0x5c5c7ce44a0165f76ea4e0a89f0f7ac5cce7b2c1d1b91d0f49c1f219656b7d8c';
+const INTENT_ADDED_LOG_DATA = '0x00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000';
+
+const createMockTransactionReceipt = (transactionHash: string, intentId: string) => ({
+    transactionHash,
+    cumulativeGasUsed: BigNumber.from('100'),
+    effectiveGasPrice: BigNumber.from('1'),
+    logs: [{
+        topics: [
+            INTENT_ADDED_TOPIC,
+            intentId,
+            '0x0000000000000000000000000000000000000000000000000000000000000002'
+        ],
+        data: INTENT_ADDED_LOG_DATA
+    }]
+});
+
 describe('sendIntents', () => {
     let mockDeps: SinonStubbedInstance<MarkAdapters>;
     let getERC20ContractStub: SinonStub;
@@ -204,11 +222,9 @@ describe('sendIntents', () => {
         } as unknown as GetContractReturnType;
 
         getERC20ContractStub.resolves(mockTokenContract as any);
-        (mockDeps.chainService.submitAndMonitor as SinonStub).resolves({
-            transactionHash: '0xintentTx', cumulativeGasUsed: BigNumber.from('100'), effectiveGasPrice: BigNumber.from('1'), logs: [{
-                topics: [INTENT_ADDED_TOPIC0, '0xintentid']
-            }]
-        });
+        (mockDeps.chainService.submitAndMonitor as SinonStub).resolves(
+            createMockTransactionReceipt('0xintentTx', '0x0000000000000000000000000000000000000000000000000000000000000000')
+        );
 
         const intentsArray = Array.from(batch.values()).flatMap((assetMap) => Array.from(assetMap.values()));
 
@@ -225,8 +241,8 @@ describe('sendIntents', () => {
             mockConfig,
         );
 
-        expect((mockDeps.chainService.submitAndMonitor as SinonStub).callCount).to.equal(0); // Called only for intent
-        expect(result).to.deep.equal([]);
+        expect((mockDeps.chainService.submitAndMonitor as SinonStub).callCount).to.equal(1); // Called for intent
+        expect(result).to.deep.equal([{ transactionHash: '0xintentTx', chainId: '1', intentId: '0x0000000000000000000000000000000000000000000000000000000000000000' }]);
     });
 
     it('should handle cases where there is not sufficient allowance', async () => {
@@ -249,16 +265,8 @@ describe('sendIntents', () => {
 
         getERC20ContractStub.resolves(mockTokenContract as any);
         (mockDeps.chainService.submitAndMonitor as SinonStub)
-            .onFirstCall().resolves({
-                transactionHash: '0xapprovalTx', cumulativeGasUsed: BigNumber.from('100'), effectiveGasPrice: BigNumber.from('1'), logs: [{
-                    topics: [INTENT_ADDED_TOPIC0, '0xintentid']
-                }]
-            })
-            .onSecondCall().resolves({
-                transactionHash: '0xintentTx', cumulativeGasUsed: BigNumber.from('100'), effectiveGasPrice: BigNumber.from('1'), logs: [{
-                    topics: [INTENT_ADDED_TOPIC0, '0xintentid']
-                }]
-            });
+            .onFirstCall().resolves(createMockTransactionReceipt('0xapprovalTx', '0x0000000000000000000000000000000000000000000000000000000000000000'))
+            .onSecondCall().resolves(createMockTransactionReceipt('0xintentTx', '0x0000000000000000000000000000000000000000000000000000000000000000'));
 
         const intentsArray = Array.from(batch.values()).flatMap((assetMap) => Array.from(assetMap.values()));
 
@@ -271,7 +279,7 @@ describe('sendIntents', () => {
         const result = await sendIntents(invoiceId, intentsArray, mockDeps, mockConfig);
 
         expect((mockDeps.chainService.submitAndMonitor as SinonStub).callCount).to.equal(2); // Called for both approval and intent
-        expect(result).to.deep.equal([{ transactionHash: '0xintentTx', chainId: '1', intentId: '0xintentid' }]);
+        expect(result).to.deep.equal([{ transactionHash: '0xintentTx', chainId: '1', intentId: '0x0000000000000000000000000000000000000000000000000000000000000000' }]);
     });
 
     it('should handle cases where there is sufficient allowance', async () => {
@@ -293,11 +301,9 @@ describe('sendIntents', () => {
         } as unknown as GetContractReturnType;
 
         getERC20ContractStub.resolves(mockTokenContract as any);
-        (mockDeps.chainService.submitAndMonitor as SinonStub).resolves({
-            transactionHash: '0xintentTx', cumulativeGasUsed: BigNumber.from('100'), effectiveGasPrice: BigNumber.from('1'), logs: [{
-                topics: [INTENT_ADDED_TOPIC0, '0xintentid']
-            }]
-        });
+        (mockDeps.chainService.submitAndMonitor as SinonStub).resolves(
+            createMockTransactionReceipt('0xintentTx', '0x0000000000000000000000000000000000000000000000000000000000000000')
+        );
 
         const intentsArray = Array.from(batch.values()).flatMap((assetMap) => Array.from(assetMap.values()));
 
@@ -315,7 +321,7 @@ describe('sendIntents', () => {
         );
 
         expect((mockDeps.chainService.submitAndMonitor as SinonStub).callCount).to.equal(1); // Called only for intent
-        expect(result).to.deep.equal([{ transactionHash: '0xintentTx', chainId: '1', intentId: '0xintentid' }]);
+        expect(result).to.deep.equal([{ transactionHash: '0xintentTx', chainId: '1', intentId: '0x0000000000000000000000000000000000000000000000000000000000000000' }]);
     });
 
     it('should throw an error when sending multiple intents with different input assets', async () => {
@@ -344,7 +350,7 @@ describe('sendIntents', () => {
             .to.be.rejectedWith('Cannot process multiple intents with different input assets');
     });
 
-    it('should process multiple intents with the same origin and input asset individually', async () => {
+    it('should process multiple intents with the same origin and input asset in a single transaction', async () => {
         const sameOriginSameAssetIntents = [
             {
                 origin: '1',
@@ -366,35 +372,14 @@ describe('sendIntents', () => {
             }
         ];
 
-        // Set up createNewIntent to handle multiple calls
+        // Set up createNewIntent to handle the batch call
         const createNewIntentStub = mockDeps.everclear.createNewIntent as SinonStub;
-
-        createNewIntentStub.callsFake((intent: NewIntentParams) => {
-            if (intent.to === '0xto1') {
-                return Promise.resolve({
-                    to: '0xspoke1',
-                    data: '0xdata1',
-                    chainId: '1',
-                    from: mockConfig.ownAddress,
-                    value: '0',
-                });
-            } else if (intent.to === '0xto2') {
-                return Promise.resolve({
-                    to: '0xspoke2',
-                    data: '0xdata2',
-                    chainId: '1',
-                    from: mockConfig.ownAddress,
-                    value: '0',
-                });
-            } else {
-                return Promise.resolve({
-                    to: '0xspoke_default',
-                    data: '0xdata_default',
-                    chainId: '1',
-                    from: mockConfig.ownAddress,
-                    value: '0',
-                });
-            }
+        createNewIntentStub.resolves({
+            to: '0xspoke1',
+            data: '0xdata1',
+            chainId: '1',
+            from: mockConfig.ownAddress,
+            value: '0',
         });
 
         (mockDeps.everclear.getMinAmounts as SinonStub).resolves({
@@ -412,34 +397,30 @@ describe('sendIntents', () => {
 
         getERC20ContractStub.resolves(mockTokenContract as any);
 
-        // Mock transaction responses for both intents
-        (mockDeps.chainService.submitAndMonitor as SinonStub)
-            .onFirstCall().resolves({
-                transactionHash: '0xintentTx1',
-                cumulativeGasUsed: BigNumber.from('100'),
-                effectiveGasPrice: BigNumber.from('1'),
-                logs: [{
-                    topics: [INTENT_ADDED_TOPIC0, '0xintentid1']
-                }]
-            })
-            .onSecondCall().resolves({
-                transactionHash: '0xintentTx2',
-                cumulativeGasUsed: BigNumber.from('100'),
-                effectiveGasPrice: BigNumber.from('1'),
-                logs: [{
-                    topics: [INTENT_ADDED_TOPIC0, '0xintentid2']
-                }]
-            });
+        // Mock transaction response with both intent IDs in the OrderCreated event
+        (mockDeps.chainService.submitAndMonitor as SinonStub).resolves({
+            transactionHash: '0xbatchTx',
+            cumulativeGasUsed: BigNumber.from('100'),
+            effectiveGasPrice: BigNumber.from('1'),
+            logs: [{
+                topics: [
+                    '0x5c5c7ce44a0165f76ea4e0a89f0f7ac5cce7b2c1d1b91d0f49c1f219656b7d8c',
+                    '0x0000000000000000000000000000000000000000000000000000000000000001',
+                    '0x0000000000000000000000000000000000000000000000000000000000000002'
+                ],
+                data: '0x00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+            }]
+        });
 
         const result = await sendIntents(invoiceId, sameOriginSameAssetIntents, mockDeps, mockConfig);
 
-        // Should be called twice - once for each intent
-        expect((mockDeps.chainService.submitAndMonitor as SinonStub).callCount).to.equal(2);
+        // Should be called once for the batch
+        expect((mockDeps.chainService.submitAndMonitor as SinonStub).callCount).to.equal(1);
 
         // Results should contain transaction info for both intents
         expect(result).to.deep.equal([
-            { transactionHash: '0xintentTx1', chainId: '1', intentId: '0xintentid1' },
-            { transactionHash: '0xintentTx2', chainId: '1', intentId: '0xintentid2' }
+            { transactionHash: '0xbatchTx', chainId: '1', intentId: '0x0000000000000000000000000000000000000000000000000000000000000001' },
+            { transactionHash: '0xbatchTx', chainId: '1', intentId: '0x0000000000000000000000000000000000000000000000000000000000000002' }
         ]);
     });
 });
@@ -657,7 +638,12 @@ describe('sendIntentsMulticall', () => {
             effectiveGasPrice: BigNumber.from('5'),
             logs: [
                 {
-                    topics: [INTENT_ADDED_TOPIC0, '0xintentid1']
+                    topics: [
+                        '0x5c5c7ce44a0165f76ea4e0a89f0f7ac5cce7b2c1d1b91d0f49c1f219656b7d8c',
+                        '0x0000000000000000000000000000000000000000000000000000000000000001',
+                        '0x0000000000000000000000000000000000000000000000000000000000000002'
+                    ],
+                    data: '0x00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000'
                 }
             ]
         });
@@ -693,12 +679,8 @@ describe('sendIntentsMulticall', () => {
             cumulativeGasUsed: BigNumber.from('200000'),
             effectiveGasPrice: BigNumber.from('5'),
             logs: [
-                {
-                    topics: [INTENT_ADDED_TOPIC0, '0xintentid1']
-                },
-                {
-                    topics: [INTENT_ADDED_TOPIC0, '0xintentid2']
-                }
+                createMockTransactionReceipt('0xmulticallTx', '0x0000000000000000000000000000000000000000000000000000000000000001').logs[0],
+                createMockTransactionReceipt('0xmulticallTx', '0x0000000000000000000000000000000000000000000000000000000000000002').logs[0]
             ]
         });
 

--- a/packages/poller/test/invoice/processInvoices.spec.ts
+++ b/packages/poller/test/invoice/processInvoices.spec.ts
@@ -914,8 +914,8 @@ describe('Invoice Processing', () => {
       expect(mockDeps.logger.info.calledWith('No valid origins remain after filtering existing purchases')).to.be.true;
     });
 
-    it('should skip other invoices when prioritizeOldestInvoice is true and oldest invoice has no valid allocation', async () => {
-      mockContext.config.prioritizeOldestInvoice = true;
+    it('should skip other invoices when forceOldestInvoice is true and oldest invoice has no valid allocation', async () => {
+      mockContext.config.forceOldestInvoice = true;
       isXerc20SupportedStub.resolves(false);
 
       const oldestInvoice = createMockInvoice({
@@ -956,8 +956,8 @@ describe('Invoice Processing', () => {
       expect(result.purchases).to.deep.equal([]);
     });
 
-    it('should process newer invoices when prioritizeOldestInvoice is false and oldest invoice has no valid allocation', async () => {
-      mockContext.config.prioritizeOldestInvoice = false;
+    it('should process newer invoices when forceOldestInvoice is false and oldest invoice has no valid allocation', async () => {
+      mockContext.config.forceOldestInvoice = false;
       isXerc20SupportedStub.resolves(false);
 
       const oldestInvoice = createMockInvoice({

--- a/packages/poller/test/invoice/processInvoices.spec.ts
+++ b/packages/poller/test/invoice/processInvoices.spec.ts
@@ -1,840 +1,1178 @@
-import { expect } from 'chai';
-import { stub, SinonStubbedInstance, createStubInstance, SinonStub } from 'sinon';
-import sinon from 'sinon';
-import { processInvoices } from '../../src/invoice/processInvoices';
-import { MarkConfiguration, Invoice, NewIntentParams, InvalidPurchaseReasons } from '@mark/core';
-import { PurchaseCache, PurchaseAction } from '@mark/cache';
-import { Logger } from '@mark/logger';
-import { EverclearAdapter, MinAmountsResponse, IntentStatus } from '@mark/everclear';
-import { Web3Signer } from '@mark/web3signer';
-import { Wallet } from '@ethersproject/wallet';
-import { ChainService } from '@mark/chainservice';
-import { InvoiceLabels, PrometheusAdapter } from '@mark/prometheus';
+import { expect } from '../globalTestHook';
+import sinon, { createStubInstance, SinonStubbedInstance, SinonStub } from 'sinon';
+import { ProcessingContext } from '../../src/init';
+import { processInvoices, processTickerGroup, TickerGroup } from '../../src/invoice/processInvoices';
 import * as balanceHelpers from '../../src/helpers/balance';
+import * as assetHelpers from '../../src/helpers/asset';
+import { IntentStatus } from '@mark/everclear';
+import { PurchaseAction } from '@mark/cache';
+import { NewIntentParams, MarkConfiguration, Invoice, InvalidPurchaseReasons } from '@mark/core';
+import { Logger } from '@mark/logger';
+import { EverclearAdapter } from '@mark/everclear';
+import { ChainService } from '@mark/chainservice';
+import { PurchaseCache } from '@mark/cache';
+import { Wallet, BigNumber } from 'ethers';
+import { PrometheusAdapter } from '@mark/prometheus';
 import * as intentHelpers from '../../src/helpers/intent';
-import * as assetHelpers from '../../src/helpers/asset'
-import * as monitorHelpers from '../../src/helpers/monitor';
 import * as splitIntentHelpers from '../../src/helpers/splitIntent';
+import { MAX_DESTINATIONS } from '../../src/invoice/processInvoices';
 
-describe('processInvoices', () => {
-    // Setup common test objects
-    const validInvoice: Invoice = {
-        intent_id: '0x123',
-        owner: '0xowner',
-        entry_epoch: 186595,
-        amount: '1000000000000000000',
-        discountBps: 1.2,
-        origin: '8453',
-        destinations: ['1'],
-        hub_status: 'INVOICED',
-        ticker_hash: '0xtickerhash',
-        hub_invoice_enqueued_timestamp: Math.floor(Date.now() / 1000) - 3600,
-    };
+describe('Invoice Processing', () => {
+  let mockContext: SinonStubbedInstance<ProcessingContext>;
 
-    const validMinApiResponse: MinAmountsResponse = {
-        invoiceAmount: '1023',
-        discountBps: '1.2',
-        amountAfterDiscount: '1020',
-        custodiedAmounts: {
-            '1': '1000000000000000000'
-        },
-        minAmounts: {
-            '1': '1000000000000000000'
-        }
-    }
+  let getMarkBalancesStub: SinonStub;
+  let getMarkGasBalancesStub: SinonStub;
+  let getCustodiedBalancesStub: SinonStub;
+  let isXerc20SupportedStub: SinonStub;
+  let calculateSplitIntentsStub: SinonStub;
+  let sendIntentsStub: SinonStub;
 
-    const validConfig: MarkConfiguration = {
-        pushGatewayUrl: 'http://localhost:9090',
-        web3SignerUrl: 'http://localhost:8545',
-        relayer: {
-            url: 'http://localhost:8000',
-            key: 'test-key'
-        },
-        ownAddress: '0xmark',
-        supportedSettlementDomains: [8453, 1],
+  let mockDeps: {
+    logger: SinonStubbedInstance<Logger>;
+    everclear: SinonStubbedInstance<EverclearAdapter>;
+    chainService: SinonStubbedInstance<ChainService>;
+    cache: SinonStubbedInstance<PurchaseCache>;
+    web3Signer: SinonStubbedInstance<Wallet>;
+    prometheus: SinonStubbedInstance<PrometheusAdapter>;
+    config: MarkConfiguration;
+  };
+
+  // Default single-dest mock invoice
+  function createMockInvoice(overrides?: Partial<Invoice>): Invoice {
+    return {
+      intent_id: '0x123',
+      amount: '1000000000000000000',
+      origin: '1',
+      destinations: ['8453'],
+      ticker_hash: '0xticker1',
+      hub_invoice_enqueued_timestamp: Date.now() - 7200000,
+      source_domain: '1',
+      target_domain: '8453',
+      source_address: '0xsource',
+      target_address: '0xtarget',
+      source_token_address: '0xtoken1',
+      target_token_address: '0xtoken2',
+      status: 'PENDING',
+      owner: '0xowner',
+      entry_epoch: 0,
+      discountBps: 0,
+      hub_status: 'PENDING',
+      severity: 0,
+      ...overrides,
+    } as Invoice;
+  }
+
+  beforeEach(() => {
+    // Init with fresh stubs and mocks
+    getMarkBalancesStub = sinon.stub(balanceHelpers, 'getMarkBalances');
+    getMarkGasBalancesStub = sinon.stub(balanceHelpers, 'getMarkGasBalances');
+    getCustodiedBalancesStub = sinon.stub(balanceHelpers, 'getCustodiedBalances');
+    isXerc20SupportedStub = sinon.stub(assetHelpers, 'isXerc20Supported');
+    calculateSplitIntentsStub = sinon.stub(splitIntentHelpers, 'calculateSplitIntents');
+    sendIntentsStub = sinon.stub(intentHelpers, 'sendIntents');
+
+    // Default mock config supports 1, 8453, 10 and one token on each
+    mockDeps = {
+      logger: createStubInstance(Logger),
+      everclear: createStubInstance(EverclearAdapter),
+      chainService: createStubInstance(ChainService),
+      cache: createStubInstance(PurchaseCache),
+      web3Signer: createStubInstance(Wallet),
+      prometheus: createStubInstance(PrometheusAdapter),
+      config: {
         chains: {
-            '1': {
-                invoiceAge: 3600,
-                providers: ['provider'],
-                gasThreshold: '1000000000000000000',
-                deployments: {
-                    everclear: '0xspoke',
-                    permit2: '0xpermit2',
-                    multicall3: '0xmulticall3'
-                },
-                assets: [{
-                    tickerHash: '0xtickerhash',
-                    address: '0xtoken',
-                    decimals: 18,
-                    symbol: 'TEST',
-                    isNative: false,
-                    balanceThreshold: '1000000000000000000'
-                }]
+          '1': {
+            providers: ['http://localhost:8545'],
+            assets: [{
+              tickerHash: '0xticker1',
+              address: '0xtoken1',
+              decimals: 18,
+              symbol: 'TEST',
+              isNative: false,
+              balanceThreshold: '1000000000000000000',
+            }],
+            deployments: {
+              everclear: '0x1234567890123456789012345678901234567890',
+              permit2: '0x1234567890123456789012345678901234567890',
+              multicall3: '0x1234567890123456789012345678901234567890'
             },
-            '8453': {
-                invoiceAge: 3600,
-                providers: ['provider'],
-                gasThreshold: '1000000000000000000',
-                deployments: {
-                    everclear: '0xspoke',
-                    permit2: '0xpermit2',
-                    multicall3: '0xmulticall3'
-                },
-                assets: [{
-                    tickerHash: '0xtickerhash',
-                    address: '0xtoken',
-                    decimals: 18,
-                    symbol: 'TEST',
-                    isNative: false,
-                    balanceThreshold: '1000000000000000000'
-                }]
-            }
+            invoiceAge: 3600,
+            gasThreshold: '1000000000000000000'
+          },
+          '8453': {
+            providers: ['http://localhost:8545'],
+            assets: [{
+              tickerHash: '0xticker1',
+              address: '0xtoken1',
+              decimals: 18,
+              symbol: 'TEST',
+              isNative: false,
+              balanceThreshold: '1000000000000000000',
+            }],
+            deployments: {
+              everclear: '0x1234567890123456789012345678901234567890',
+              permit2: '0x1234567890123456789012345678901234567890',
+              multicall3: '0x1234567890123456789012345678901234567890'
+            },
+            invoiceAge: 3600,
+            gasThreshold: '1000000000000000000'
+          },
+          '10': {
+            providers: ['http://localhost:8545'],
+            assets: [{
+              tickerHash: '0xticker1',
+              address: '0xtoken1',
+              decimals: 18,
+              symbol: 'TEST',
+              isNative: false,
+              balanceThreshold: '1000000000000000000',
+            }],
+            deployments: {
+              everclear: '0x1234567890123456789012345678901234567890',
+              permit2: '0x1234567890123456789012345678901234567890',
+              multicall3: '0x1234567890123456789012345678901234567890'
+            },
+            invoiceAge: 3600,
+            gasThreshold: '1000000000000000000'
+          },
         },
-        logLevel: 'info',
+        prioritizeOldestInvoice: false,
+        pushGatewayUrl: 'http://localhost:9091',
+        web3SignerUrl: 'http://localhost:8545',
         everclearApiUrl: 'http://localhost:3000',
-        stage: 'development',
-        environment: 'testnet',
-        supportedAssets: ['TEST'],
-        redis: {
-            host: 'localhost',
-            port: 6379
+        relayer: {
+          url: 'http://localhost:8080',
+          apiKey: 'test'
         },
+        hubChain: 1,
+        hubMainnetChain: 1,
+        hubStorageAddress: '0x1234567890123456789012345678901234567890',
+        permit2Address: '0x1234567890123456789012345678901234567890',
+        multicallAddress: '0x1234567890123456789012345678901234567890',
+        balanceThresholds: {},
+        gasThresholds: {},
+        redis: {
+          host: 'localhost',
+          port: 6379
+        },
+        ownAddress: '0x1234567890123456789012345678901234567890',
+        stage: 'development',
+        environment: 'devnet',
+        logLevel: 'debug',
+        supportedAssets: ['0xticker1'],
+        supportedSettlementDomains: [1, 8453],
         hub: {
-            domain: '1',
-            providers: ['provider']
+          domain: '1',
+          providers: ['http://localhost:8545'],
+          assets: [{
+            tickerHash: '0xticker1',
+            address: '0xtoken1',
+            decimals: 18,
+            symbol: 'TEST',
+            isNative: false,
+            balanceThreshold: '1000000000000000000'
+          }]
         }
+      } as MarkConfiguration
     };
 
-    // Setup label constants
-    const labels: InvoiceLabels = {
-        origin: validInvoice.origin,
-        id: validInvoice.intent_id,
-        ticker: validInvoice.ticker_hash,
-    }
+    mockContext = {
+      requestId: 'test-request-id',
+      startTime: Date.now(),
+      ...mockDeps
+    };
+  });
 
-    // Setup mocks
-    let cache: SinonStubbedInstance<PurchaseCache>;
-    let logger: SinonStubbedInstance<Logger>;
-    let everclear: SinonStubbedInstance<EverclearAdapter>;
-    let chainService: SinonStubbedInstance<ChainService>;
-    let prometheus: SinonStubbedInstance<PrometheusAdapter>;
-    let web3Signer: SinonStubbedInstance<Web3Signer>;
-    let typedWeb3Signer: Web3Signer & Wallet;
-    let markBalanceStub: SinonStub;
-    let calcSplitIntentsStub: SinonStub;
-    let sendIntentsStub: SinonStub;
-    let sendIntentsMulticallStub: SinonStub;
+  afterEach(() => {
+    sinon.restore();
+  });
 
-    beforeEach(() => {
-        cache = createStubInstance(PurchaseCache);
-        logger = createStubInstance(Logger);
-        everclear = createStubInstance(EverclearAdapter);
-        chainService = createStubInstance(ChainService);
-        prometheus = createStubInstance(PrometheusAdapter);
-        web3Signer = createStubInstance(Web3Signer);
-        typedWeb3Signer = web3Signer as unknown as Web3Signer & Wallet;
+  describe('processInvoices', () => {
+    it('should remove stale cache purchases successfully', async () => {
+      getMarkBalancesStub.resolves(new Map());
+      getMarkGasBalancesStub.resolves(new Map());
+      getCustodiedBalancesStub.resolves(new Map());
+      isXerc20SupportedStub.resolves(false);
 
-        // Setup default stubs
-        cache.getAllPurchases.resolves([]);
-        cache.removePurchases.resolves();
-        cache.addPurchases.resolves();
+      // Make invoice SETTLED, which means it should be removed
+      mockDeps.everclear.intentStatus.resolves(IntentStatus.SETTLED);
 
-        // Setup prometheus stubs
-        prometheus.updateChainBalance.resolves();
-        prometheus.updateGasBalance.resolves();
-        prometheus.recordPossibleInvoice.resolves();
-        prometheus.recordSuccessfulPurchase.resolves();
-        prometheus.recordInvoicePurchaseDuration.resolves();
+      const invoices = [createMockInvoice()];
 
-        // Setup everclear stubs
-        everclear.getMinAmounts.resolves(validMinApiResponse);
-        everclear.intentStatus.resolves(IntentStatus.ADDED);
-        everclear.createNewIntent.resolves({
-            to: '0xdestination',
-            data: '0xdata',
-            chainId: 1,
-            value: '0'
-        });
-
-        markBalanceStub = stub(balanceHelpers, 'getMarkBalances').resolves(new Map([
-            ['0xtickerhash', new Map([
-                ['1', BigInt('2000000000000000000')],
-                ['8453', BigInt('0')]
-            ])]
-        ]));
-
-        stub(balanceHelpers, 'getMarkGasBalances').resolves(new Map([
-            ['1', BigInt('1000000000000000000')],
-            ['8453', BigInt('0')]
-        ]));
-
-        // Setup intent helper stubs
-        sendIntentsStub = stub(intentHelpers, 'sendIntents').resolves([{
-            transactionHash: '0xtx',
-            chainId: '1',
-            intentId: '0xintent'
-        }]);
-
-        sendIntentsMulticallStub = stub(intentHelpers, 'sendIntentsMulticall').resolves({
-            transactionHash: '0xmulticall_tx',
-            chainId: '1',
-            intentId: '0xmulticall_intent'
-        });
-
-        // Setup calculateSplitIntents stub with default single intent behavior
-        calcSplitIntentsStub = stub(splitIntentHelpers, 'calculateSplitIntents').resolves({
-            intents: [{
-                origin: '1',
-                destinations: ['8453'],
-                to: '0xdestination',
-                inputAsset: '0xtoken',
-                amount: '1000000000000000000',
-                callData: '0xdata',
-                maxFee: '0'
-            }],
-            originDomain: '1',
-            totalAllocated: BigInt('1000000000000000000')
-        });
-
-        stub(assetHelpers, 'isXerc20Supported').resolves(false);
-        stub(assetHelpers, 'getTickers').returns(['0xtickerhash']);
-        stub(monitorHelpers, 'logBalanceThresholds').returns();
-        stub(monitorHelpers, 'logGasThresholds').returns();
-    });
-
-    afterEach(() => {
-        sinon.restore();
-    });
-
-    it('should process a valid invoice with a single intent', async () => {
-        // Setup for a single intent scenario
-        calcSplitIntentsStub.resolves({
-            intents: [{
-                origin: '1',
-                destinations: ['8453'],
-                to: '0xdestination',
-                inputAsset: '0xtoken',
-                amount: '1000000000000000000',
-                callData: '0xdata',
-                maxFee: '0'
-            }],
-            originDomain: '1',
-            totalAllocated: BigInt('1000000000000000000')
-        });
-
-        await processInvoices({
-            invoices: [validInvoice],
-            cache,
-            logger,
-            everclear,
-            chainService,
-            prometheus,
-            config: validConfig,
-            web3Signer: typedWeb3Signer
-        });
-
-        // Verify calculateSplitIntents was called
-        expect(calcSplitIntentsStub.calledOnce).to.be.true;
-
-        // Verify sendIntents was called with the correct parameters
-        expect(sendIntentsStub.calledOnce).to.be.true;
-        expect(sendIntentsStub.firstCall.args[1]).to.deep.equal([{
-            origin: '1',
-            destinations: ['8453'],
-            to: '0xdestination',
-            inputAsset: '0xtoken',
+      // Mock the returned purchase from cache
+      mockDeps.cache.getAllPurchases.resolves([{
+        target: invoices[0],
+        purchase: { 
+          intentId: invoices[0].intent_id,
+          params: {
             amount: '1000000000000000000',
-            callData: '0xdata',
+            origin: '1',
+            destinations: ['1'],
+            to: '0x123',
+            inputAsset: '0x123',
+            callData: '',
+            maxFee: 0
+          }
+        },
+        transactionHash: '0xabc'
+      }]);
+
+      await processInvoices(mockContext, invoices);
+      
+      expect(mockDeps.cache.removePurchases.calledWith(['0x123'])).to.be.true;
+    });
+
+    it('should correctly store a purchase in the cache', async () => {
+      getMarkBalancesStub.resolves(new Map());
+      getMarkGasBalancesStub.resolves(new Map());
+      getCustodiedBalancesStub.resolves(new Map());
+      isXerc20SupportedStub.resolves(false);
+      mockDeps.cache.getAllPurchases.resolves([]);
+      mockDeps.everclear.intentStatus.resolves(IntentStatus.ADDED);
+
+      const invoice = createMockInvoice();
+      
+      mockDeps.everclear.getMinAmounts.resolves({
+        minAmounts: { '8453': '1000000000000000000' },
+        invoiceAmount: '1000000000000000000',
+        amountAfterDiscount: '1000000000000000000',
+        discountBps: '0',
+        custodiedAmounts: {}
+      });
+
+      calculateSplitIntentsStub.resolves({
+        intents: [{
+          amount: '1000000000000000000',
+          origin: '8453',
+          destinations: ['1', '10'],
+          to: '0xowner',
+          inputAsset: '0xtoken1',
+          callData: '0x',
+          maxFee: '0'
+        }],
+        originDomain: '8453',
+        totalAllocated: BigInt('1000000000000000000')
+      });
+
+      sendIntentsStub.resolves([{
+        intentId: '0xabc',
+        transactionHash: '0xabc',
+        chainId: '8453'
+      }]);
+
+      await processInvoices(mockContext, [invoice]);
+      
+      const expectedPurchase = {
+        target: invoice,
+        transactionHash: '0xabc',
+        purchase: {
+          intentId: '0xabc',
+          params: {
+            amount: '1000000000000000000',
+            origin: '8453',
+            destinations: ['1', '10'],
+            to: '0xowner',
+            inputAsset: '0xtoken1',
+            callData: '0x',
             maxFee: '0'
-        }]);
-        expect(sendIntentsStub.firstCall.args[3]).to.equal(validConfig);
-        expect(sendIntentsMulticallStub.called).to.be.false;
-
-        // Verify purchase was added to cache
-        expect(cache.addPurchases.calledOnce).to.be.true;
-        const purchases = cache.addPurchases.firstCall.args[0];
-        expect(purchases).to.have.lengthOf(1);
-        expect(purchases[0].target).to.deep.equal(validInvoice);
-        expect(purchases[0].transactionHash).to.equal('0xtx');
-
-        // Verify metrics were recorded
-        expect(prometheus.recordSuccessfulPurchase.calledOnce).to.be.true;
-        const successfulPurchaseCall2 = prometheus.recordSuccessfulPurchase.firstCall;
-        expect(successfulPurchaseCall2.args[0]).to.include({
-            origin: labels.origin,
-            id: labels.id,
-            ticker: labels.ticker,
-            destination: '1'
-        });
-        expect(prometheus.recordPossibleInvoice.callCount).to.be.greaterThan(0);
-        expect(prometheus.recordInvoicePurchaseDuration.calledOnce).to.be.true;
-    });
-
-    it('should process a valid invoice with multiple intents', async () => {
-        // Setup for a multiple intent scenario
-        calcSplitIntentsStub.resolves({
-            intents: [
-                {
-                    origin: '1',
-                    destinations: ['8453'],
-                    to: '0xdestination1',
-                    inputAsset: '0xtoken1',
-                    amount: '500000000000000000',
-                    callData: '0xdata1',
-                    maxFee: '0'
-                },
-                {
-                    origin: '1',
-                    destinations: ['8453'],
-                    to: '0xdestination2',
-                    inputAsset: '0xtoken2',
-                    amount: '500000000000000000',
-                    callData: '0xdata2',
-                    maxFee: '0'
-                }
-            ],
-            originDomain: '1',
-            totalAllocated: BigInt('1000000000000000000')
-        });
-
-        // For multiple intents testing, update the sendIntents stub to return multiple results
-        sendIntentsStub.resolves([
-            {
-                transactionHash: '0xtx1',
-                chainId: '1',
-                intentId: '0xintent1'
-            },
-            {
-                transactionHash: '0xtx2',
-                chainId: '1',
-                intentId: '0xintent2'
-            }
-        ]);
-
-        await processInvoices({
-            invoices: [validInvoice],
-            cache,
-            logger,
-            everclear,
-            chainService,
-            prometheus,
-            config: validConfig,
-            web3Signer: typedWeb3Signer
-        });
-
-        // Verify calculateSplitIntents was called
-        expect(calcSplitIntentsStub.calledOnce).to.be.true;
-
-        // Verify sendIntents was called with multiple intents and originDomain
-        expect(sendIntentsStub.calledOnce).to.be.true;
-        expect(sendIntentsStub.firstCall.args[1]).to.have.lengthOf(2);
-        expect(sendIntentsMulticallStub.called).to.be.false; // Should not be called directly anymore
-
-        // Verify purchases were added to cache - now we should have multiple purchases
-        expect(cache.addPurchases.calledOnce).to.be.true;
-        const purchases = cache.addPurchases.firstCall.args[0];
-        expect(purchases).to.have.lengthOf(2); // Now expecting 2 purchases
-        expect(purchases[0].target).to.deep.equal(validInvoice);
-        expect(purchases[0].transactionHash).to.equal('0xtx1');
-        expect(purchases[1].target).to.deep.equal(validInvoice);
-        expect(purchases[1].transactionHash).to.equal('0xtx2');
-
-        // Verify metrics were recorded
-        expect(prometheus.recordSuccessfulPurchase.calledOnce).to.be.true;
-        const successfulPurchaseCall2 = prometheus.recordSuccessfulPurchase.firstCall;
-        expect(successfulPurchaseCall2.args[0]).to.include({
-            origin: labels.origin,
-            id: labels.id,
-            ticker: labels.ticker,
-            destination: '1'
-        });
-        expect(prometheus.recordPossibleInvoice.callCount).to.be.greaterThan(0);
-        expect(prometheus.recordInvoicePurchaseDuration.calledOnce).to.be.true;
-    });
-
-    it('should skip processing if invoice already has a pending purchase', async () => {
-        const existingPurchase: PurchaseAction = {
-            target: validInvoice,
-            purchase: { intentId: '0xintent', params: {} as NewIntentParams },
-            transactionHash: '0xexisting'
-        };
-        cache.getAllPurchases.resolves([existingPurchase]);
-
-        await processInvoices({
-            invoices: [validInvoice],
-            cache,
-            logger,
-            everclear,
-            chainService,
-            prometheus,
-            config: validConfig,
-            web3Signer: typedWeb3Signer
-        });
-
-        // Verify we don't try to process this invoice
-        expect(everclear.getMinAmounts.called).to.be.false;
-        expect(calcSplitIntentsStub.called).to.be.false;
-        expect(sendIntentsStub.called).to.be.false;
-        expect(sendIntentsMulticallStub.called).to.be.false;
-
-        // Verify we add the existing purchase to the cache
-        expect(cache.addPurchases.calledOnceWith([existingPurchase])).to.be.true;
-
-        // Verify proper metrics were recorded
-        expect(prometheus.recordPossibleInvoice.called).to.be.true;
-        expect(prometheus.recordInvalidPurchase.calledOnceWith(InvalidPurchaseReasons.PendingPurchaseRecord, labels)).to.be.true;
-    });
-
-    it('should skip processing if XERC20 is supported for the destination', async () => {
-        (assetHelpers.isXerc20Supported as any).restore();
-        stub(assetHelpers, 'isXerc20Supported').resolves(true);
-
-        await processInvoices({
-            invoices: [validInvoice],
-            cache,
-            logger,
-            everclear,
-            chainService,
-            prometheus,
-            config: validConfig,
-            web3Signer: typedWeb3Signer
-        });
-
-        // Verify we don't try to process this invoice
-        expect(everclear.getMinAmounts.called).to.be.false;
-        expect(calcSplitIntentsStub.called).to.be.false;
-        expect(sendIntentsStub.called).to.be.false;
-        expect(sendIntentsMulticallStub.called).to.be.false;
-        expect(cache.addPurchases.called).to.be.false;
-
-        // Verify proper metrics were recorded
-        expect(prometheus.recordPossibleInvoice.called).to.be.true;
-        expect(prometheus.recordInvalidPurchase.calledOnceWith(InvalidPurchaseReasons.DestinationXerc20, labels)).to.be.true;
-    });
-
-    it('should skip invoices where calculateSplitIntents returns no intents', async () => {
-        // Set up calculateSplitIntents to return no intents
-        calcSplitIntentsStub.resolves({
-            intents: [],
-            originDomain: '',
-            totalAllocated: BigInt('0')
-        });
-
-        await processInvoices({
-            invoices: [validInvoice],
-            cache,
-            logger,
-            everclear,
-            chainService,
-            prometheus,
-            config: validConfig,
-            web3Signer: typedWeb3Signer
-        });
-
-        // Verify we called calculateSplitIntents but didn't try to send intents
-        expect(calcSplitIntentsStub.calledOnce).to.be.true;
-        expect(sendIntentsStub.called).to.be.false;
-        expect(cache.addPurchases.called).to.be.false;
-
-        // Verify proper metrics were recorded
-        expect(prometheus.recordPossibleInvoice.called).to.be.true;
-        expect(prometheus.recordInvalidPurchase.calledOnceWith(InvalidPurchaseReasons.InsufficientBalance, labels)).to.be.true;
-    });
-
-    it('should handle errors during single intent transaction', async () => {
-        // Setup sendIntents to fail
-        sendIntentsStub.rejects(new Error('Transaction failed'));
-
-        await processInvoices({
-            invoices: [validInvoice],
-            cache,
-            logger,
-            everclear,
-            chainService,
-            prometheus,
-            config: validConfig,
-            web3Signer: typedWeb3Signer
-        });
-
-        // Verify error was logged and no purchase was added
-        expect(logger.error.called).to.be.true;
-        expect(cache.addPurchases.called).to.be.false;
-
-        // Verify proper metrics were recorded
-        expect(prometheus.recordPossibleInvoice.called).to.be.true;
-        expect(prometheus.recordInvalidPurchase.calledOnceWith(InvalidPurchaseReasons.TransactionFailed, {
-            ...labels,
-            destination: '1'
-        })).to.be.true;
-    });
-
-    it('should handle errors during multi-intent transaction', async () => {
-        // Setup for a multi-intent scenario
-        calcSplitIntentsStub.resolves({
-            intents: [
-                {
-                    origin: '1',
-                    destinations: ['8453'],
-                    to: '0xdestination1',
-                    inputAsset: '0xtoken',
-                    amount: '500000000000000000',
-                    callData: '0xdata1',
-                    maxFee: '0'
-                },
-                {
-                    origin: '1',
-                    destinations: ['8453'],
-                    to: '0xdestination2',
-                    inputAsset: '0xtoken',
-                    amount: '500000000000000000',
-                    callData: '0xdata2',
-                    maxFee: '0'
-                }
-            ],
-            originDomain: '1',
-            totalAllocated: BigInt('1000000000000000000')
-        });
-
-        // Setup sendIntents to fail for multiple intents
-        sendIntentsStub.rejects(new Error('Transaction failed'));
-        sendIntentsMulticallStub.resolves({ transactionHash: '0xtx', chainId: '1', intentId: '0xintent' });
-
-        await processInvoices({
-            invoices: [validInvoice],
-            cache,
-            logger,
-            everclear,
-            chainService,
-            prometheus,
-            config: validConfig,
-            web3Signer: typedWeb3Signer
-        });
-
-        // Verify error was logged and no purchase was added
-        expect(logger.error.called).to.be.true;
-        expect(cache.addPurchases.called).to.be.false;
-
-        // Verify sendIntents was called with multiple intents and originDomain
-        expect(sendIntentsStub.calledOnce).to.be.true;
-        expect(sendIntentsStub.firstCall.args[1]).to.have.lengthOf(2);
-        expect(sendIntentsMulticallStub.called).to.be.false;
-
-        // Verify proper metrics were recorded
-        expect(prometheus.recordPossibleInvoice.called).to.be.true;
-        expect(prometheus.recordInvalidPurchase.calledOnceWith(InvalidPurchaseReasons.TransactionFailed, {
-            ...labels,
-            destination: '1'
-        })).to.be.true;
-    });
-
-    it('should not handle multiple invoices with same ticker + destinations', async () => {
-        const secondInvoice = {
-            ...validInvoice,
-            intent_id: '0x456',
-            hub_invoice_enqueued_timestamp: Math.floor(Date.now() / 1000) - 3600 // 15 minutes ago
-        };
-
-        // Setup calculateSplitIntents to return reasonable results for first invoice but not second
-        calcSplitIntentsStub.onFirstCall().resolves({
-            intents: [{
-                origin: '1',
-                destinations: ['8453'],
-                to: '0xdestination',
-                inputAsset: '0xtoken',
-                amount: '1000000000000000000',
-                callData: '0xdata',
-                maxFee: '0'
-            }],
-            originDomain: '1',
-            totalAllocated: BigInt('1000000000000000000')
-        });
-
-        // Add specific stub to track metrics correctly
-        prometheus.recordInvalidPurchase.withArgs(
-            InvalidPurchaseReasons.PendingPurchaseRecord,
-            { ...labels, id: secondInvoice.intent_id }
-        ).resolves(undefined);
-
-        await processInvoices({
-            invoices: [validInvoice, secondInvoice],
-            cache,
-            logger,
-            everclear,
-            chainService,
-            prometheus,
-            config: validConfig,
-            web3Signer: typedWeb3Signer
-        });
-
-        // Should only process the older invoice
-        expect(cache.addPurchases.calledOnce).to.be.true;
-        const purchases = cache.addPurchases.firstCall.args[0];
-        expect(purchases).to.have.lengthOf(1);
-        expect(purchases[0].target.intent_id).to.equal('0x123');
-
-        // Verify proper metrics were recorded
-        expect(prometheus.recordPossibleInvoice.callCount >= 2).to.be.true;
-
-        // Replace the exact parameter matching with a more flexible approach using sinon.match
-        expect(prometheus.recordSuccessfulPurchase.calledOnce).to.be.true;
-        const successfulPurchaseCall2 = prometheus.recordSuccessfulPurchase.firstCall;
-        expect(successfulPurchaseCall2.args[0]).to.include({
-            origin: labels.origin,
-            id: labels.id,
-            ticker: labels.ticker,
-            destination: '1'
-        });
-
-        // Check that the second invoice was marked with PendingPurchaseRecord
-        const secondLabels = {
-            ...labels,
-            id: secondInvoice.intent_id
-        };
-        expect(prometheus.recordPossibleInvoice.callCount >= 2).to.be.true;
-    });
-
-    it('should handle errors when removing stale purchases from cache', async () => {
-        // Setup a cached purchase that no longer matches any invoice
-        const stalePurchase = {
-            target: { ...validInvoice, intent_id: '0xstale' },
-            purchase: { intentId: '0xintent', params: {} as NewIntentParams },
-            transactionHash: '0xold'
-        };
-        cache.getAllPurchases.resolves([stalePurchase]);
-        cache.removePurchases.rejects(new Error('Cache error'));
-
-        await processInvoices({
-            invoices: [validInvoice],
-            cache,
-            logger,
-            everclear,
-            chainService,
-            prometheus,
-            config: validConfig,
-            web3Signer: typedWeb3Signer
-        });
-
-        expect(cache.removePurchases.calledOnce).to.be.true;
-        expect(logger.warn.called).to.be.true;
-
-        // Should continue processing despite cache error
-        expect(calcSplitIntentsStub.calledOnce).to.be.true;
-        expect(sendIntentsStub.calledOnce).to.be.true;
-        expect(prometheus.recordSuccessfulPurchase.called).to.be.true;
-    });
-
-    it('should handle errors when adding purchases to cache', async () => {
-        cache.addPurchases.rejects(new Error('Failed to add purchases'));
-
-        try {
-            await processInvoices({
-                invoices: [validInvoice],
-                cache,
-                logger,
-                everclear,
-                chainService,
-                prometheus,
-                config: validConfig,
-                web3Signer: typedWeb3Signer
-            });
-            expect.fail('Should have thrown an error');
-        } catch (error: any) {
-            expect(error.message).to.include('Failed to add purchases');
-            expect(logger.error.called).to.be.true;
-            expect(cache.addPurchases.calledOnce).to.be.true;
-            expect(prometheus.recordSuccessfulPurchase.called).to.be.true;
+          }
         }
+      };
+
+      // Verify the correct purchase was stored in cache
+      expect(mockDeps.cache.addPurchases.calledOnce).to.be.true;
+      expect(mockDeps.cache.addPurchases.firstCall.args[0]).to.deep.equal([expectedPurchase]);
+    });
+  });
+
+  describe('processTickerGroup', () => {
+    it('should process a single invoice in a ticker group correctly', async () => {
+      isXerc20SupportedStub.resolves(false);
+      mockDeps.everclear.getMinAmounts.resolves({
+        minAmounts: { '8453': '1000000000000000000' },
+        invoiceAmount: '1000000000000000000',
+        amountAfterDiscount: '1000000000000000000',
+        discountBps: '0',
+        custodiedAmounts: {}
+      });
+
+      const invoice = createMockInvoice();
+      const group: TickerGroup = {
+        ticker: '0xticker1',
+        invoices: [invoice],
+        remainingBalances: new Map([['0xticker1', new Map([['8453', BigInt('1000000000000000000')]])]]),
+        remainingCustodied: new Map([['0xticker1', new Map([['8453', BigInt('0')]])]]),
+        chosenOrigin: null
+      };
+
+      calculateSplitIntentsStub.resolves({
+        intents: [{
+          amount: '1000000000000000000',
+          origin: '8453',
+          destinations: ['1', '10'],
+          to: '0xowner',
+          inputAsset: '0xtoken1',
+          callData: '0x',
+          maxFee: '0'
+        }],
+        originDomain: '8453',
+        totalAllocated: BigInt('1000000000000000000')
+      });
+
+      sendIntentsStub.resolves([{
+        intentId: '0xabc',
+        transactionHash: '0xabc',
+        chainId: '8453'
+      }]);
+
+      const result = await processTickerGroup(mockContext, group, []);
+      
+      const expectedPurchase = {
+        target: invoice,
+        transactionHash: '0xabc',
+        purchase: {
+          intentId: '0xabc',
+          params: {
+            amount: '1000000000000000000',
+            origin: '8453',
+            destinations: ['1', '10'],
+            to: '0xowner',
+            inputAsset: '0xtoken1',
+            callData: '0x',
+            maxFee: '0'
+          }
+        }
+      };
+
+      // Verify the correct purchases were created
+      expect(result.purchases).to.deep.equal([expectedPurchase]);
+
+      // And the remaining balances were updated correctly
+      expect(result.remainingBalances.get('0xticker1')?.get('8453')).to.equal(BigInt('0'));
     });
 
-    it('should filter out destinations with existing purchases', async () => {
-        // Create existing purchase for a specific destination
-        const existingPurchase: PurchaseAction = {
-            target: {
-                ...validInvoice,
-                intent_id: '0xdifferent' // Different invoice but same ticker
-            },
-            purchase: {
-                intentId: '0xexisting_intent',
-                params: {
-                    origin: '1', // This destination will be filtered out
-                    destinations: ['8453'],
-                    to: '0xdestination',
-                    inputAsset: '0xtoken',
-                    amount: '1000000000000000000',
-                    callData: '0xdata',
-                    maxFee: '0'
-                } as NewIntentParams
-            },
-            transactionHash: '0xexisting'
-        };
+    it('should process multiple invoices in a ticker group correctly', async () => {
+      isXerc20SupportedStub.resolves(false);
+      mockDeps.everclear.getMinAmounts.resolves({
+        minAmounts: { '8453': '1000000000000000000' },
+        invoiceAmount: '1000000000000000000',
+        amountAfterDiscount: '1000000000000000000',
+        discountBps: '0',
+        custodiedAmounts: {}
+      });
 
-        cache.getAllPurchases.resolves([existingPurchase]);
+      const invoice1 = createMockInvoice({ intent_id: '0x123' });
+      const invoice2 = createMockInvoice({ intent_id: '0x456' });
 
-        // Modify minAmounts to include multiple destinations
-        const multiDestResponse = {
-            ...validMinApiResponse,
-            minAmounts: {
-                '1': '1000000000000000000', // Will be filtered out
-                '42161': '500000000000000000' // Should remain
+      const group: TickerGroup = {
+        ticker: '0xticker1',
+        invoices: [invoice1, invoice2],
+        remainingBalances: new Map([['0xticker1', new Map([['8453', BigInt('2000000000000000000')]])]]),
+        remainingCustodied: new Map([['0xticker1', new Map([['8453', BigInt('0')]])]]),
+        chosenOrigin: null
+      };
+
+      // Call to calculateSplitIntents for both invoices
+      calculateSplitIntentsStub.resolves({
+        intents: [{
+          amount: '1000000000000000000',
+          origin: '8453',
+          destinations: ['1', '10'],
+          to: '0xowner',
+          inputAsset: '0xtoken1',
+          callData: '0x',
+          maxFee: '0'
+        }],
+        originDomain: '8453',
+        totalAllocated: BigInt('1000000000000000000')
+      });
+
+      sendIntentsStub.resolves([
+        {
+          intentId: '0xabc',
+          transactionHash: '0xabc',
+          chainId: '8453'
+        },
+        {
+          intentId: '0xdef',
+          transactionHash: '0xdef',
+          chainId: '8453'
+        }
+      ]);
+
+      const result = await processTickerGroup(mockContext, group, []);
+      
+      const expectedPurchases = [
+        {
+          target: invoice1,
+          transactionHash: '0xabc',
+          purchase: {
+            intentId: '0xabc',
+            params: {
+              amount: '1000000000000000000',
+              origin: '8453',
+              destinations: ['1', '10'],
+              to: '0xowner',
+              inputAsset: '0xtoken1',
+              callData: '0x',
+              maxFee: '0'
             }
-        };
-        everclear.getMinAmounts.resolves(multiDestResponse);
+          }
+        },
+        {
+          target: invoice2,
+          transactionHash: '0xdef',
+          purchase: {
+            intentId: '0xdef',
+            params: {
+              amount: '1000000000000000000',
+              origin: '8453',
+              destinations: ['1', '10'],
+              to: '0xowner',
+              inputAsset: '0xtoken1',
+              callData: '0x',
+              maxFee: '0'
+            }
+          }
+        }
+      ];
 
-        await processInvoices({
-            invoices: [validInvoice],
-            cache,
-            logger,
-            everclear,
-            chainService,
-            prometheus,
-            config: validConfig,
-            web3Signer: typedWeb3Signer
-        });
+      // Verify the correct purchases were created
+      expect(result.purchases).to.deep.equal(expectedPurchases);
 
-        // Verify calcSplitIntents was called with filtered minAmounts
-        expect(calcSplitIntentsStub.calledOnce).to.be.true;
-        const filteredMinAmounts = calcSplitIntentsStub.firstCall.args[1];
-        expect(filteredMinAmounts).to.not.have.property('1'); // Should be filtered out
-        expect(filteredMinAmounts).to.have.property('42161'); // Should remain
-
-        // Verify destination filtering was logged
-        expect(logger.info.calledWith('Action exists for destination-ticker combo, removing from consideration',
-            sinon.match({ destination: '1' }))).to.be.true;
-
-        // Verify metrics for filtered destination
-        expect(prometheus.recordInvalidPurchase.calledWith(
-            InvalidPurchaseReasons.PendingPurchaseRecord,
-            sinon.match({ destination: '1' })
-        )).to.be.true;
+      // And the remaining balances were updated correctly
+      expect(result.remainingBalances.get('0xticker1')?.get('8453')).to.equal(BigInt('0'));
     });
 
-    it('should skip invoice when all destinations are filtered out', async () => {
-        // Create a specific invoice with known values
-        const testInvoice = {
-            ...validInvoice,
-            ticker_hash: '0xspecific_ticker_hash',
-            intent_id: '0xtest_invoice_id'
-        };
+    it('should process split purchases for a single invoice correctly', async () => {
+      isXerc20SupportedStub.resolves(false);
+      mockDeps.everclear.getMinAmounts.resolves({
+        minAmounts: { '8453': '2000000000000000000' },
+        invoiceAmount: '2000000000000000000',
+        amountAfterDiscount: '2000000000000000000',
+        discountBps: '0',
+        custodiedAmounts: {}
+      });
 
-        // Create existing purchase that exactly matches our test invoice's ticker_hash
-        const existingPurchase: PurchaseAction = {
-            target: {
-                ...testInvoice,
-                intent_id: '0xdifferent' // Different invoice ID but same ticker_hash
-            },
-            purchase: {
-                intentId: '0xexisting_intent',
-                params: {
-                    origin: '1', // This is the only destination in our minAmounts
-                    destinations: ['8453'],
-                    to: '0xdestination',
-                    inputAsset: '0xtoken',
-                    amount: '1000000000000000000',
-                    callData: '0xdata',
-                    maxFee: '0'
-                } as NewIntentParams
-            },
-            transactionHash: '0xexisting'
-        };
+      const invoice = createMockInvoice();
+      const group: TickerGroup = {
+        ticker: '0xticker1',
+        invoices: [invoice],
+        remainingBalances: new Map([['0xticker1', new Map([['8453', BigInt('2000000000000000000')]])]]),
+        remainingCustodied: new Map([['0xticker1', new Map([['8453', BigInt('0')]])]]),
+        chosenOrigin: null
+      };
 
-        cache.getAllPurchases.resolves([existingPurchase]);
+      // Two split intents to settle this invoice
+      calculateSplitIntentsStub.resolves({
+        intents: [
+          {
+            amount: '1000000000000000000',
+            origin: '8453',
+            destinations: ['1', '10'], // 1 is the target dest
+            to: '0xowner',
+            inputAsset: '0xtoken1',
+            callData: '0x',
+            maxFee: '0'
+          },
+          {
+            amount: '1000000000000000000',
+            origin: '8453',
+            destinations: ['10', '1'], // 10 is the target dest
+            to: '0xowner',
+            inputAsset: '0xtoken1',
+            callData: '0x',
+            maxFee: '0'
+          }
+        ],
+        originDomain: '8453',
+        totalAllocated: BigInt('2000000000000000000')
+      });
 
-        // Set up minAmounts to ONLY include the destination that will be filtered
-        const singleDestResponse = {
-            ...validMinApiResponse,
-            minAmounts: {
-                '1': '1000000000000000000' // Only this destination, which will be filtered out
+      sendIntentsStub.resolves([
+        {
+          intentId: '0xabc',
+          transactionHash: '0xabc',
+          chainId: '8453'
+        },
+        {
+          intentId: '0xdef',
+          transactionHash: '0xdef',
+          chainId: '8453'
+      }]);
+
+      const result = await processTickerGroup(mockContext, group, []);
+      
+      const expectedPurchases = [
+        {
+          target: invoice,
+          transactionHash: '0xabc',
+          purchase: {
+            intentId: '0xabc',
+            params: {
+              amount: '1000000000000000000',
+              origin: '8453',
+              destinations: ['1', '10'],
+              to: '0xowner',
+              inputAsset: '0xtoken1',
+              callData: '0x',
+              maxFee: '0'
             }
-        };
-        everclear.getMinAmounts.resolves(singleDestResponse);
+          }
+        },
+        {
+          target: invoice,
+          transactionHash: '0xdef',
+          purchase: {
+            intentId: '0xdef',
+            params: {
+              amount: '1000000000000000000',
+              origin: '8453',
+              destinations: ['10', '1'],
+              to: '0xowner',
+              inputAsset: '0xtoken1',
+              callData: '0x',
+              maxFee: '0'
+            }
+          }
+        }
+      ];
 
-        await processInvoices({
-            invoices: [testInvoice],
-            cache,
-            logger,
-            everclear,
-            chainService,
-            prometheus,
-            config: validConfig,
-            web3Signer: typedWeb3Signer
-        });
+      // Verify the correct split intent purchases were created
+      expect(result.purchases).to.deep.equal(expectedPurchases);
 
-        expect(calcSplitIntentsStub.called).to.be.false;
-        expect(sendIntentsStub.called).to.be.false;
-        expect(sendIntentsMulticallStub.called).to.be.false;
+      // And the remaining balances were updated correctly
+      expect(result.remainingBalances.get('0xticker1')?.get('8453')).to.equal(BigInt('0'));
     });
 
-    it('should correctly handle multiple pending purchases with different ticker-destination combinations', async () => {
-        // Create two existing purchases for different ticker-destination combinations
-        const existingPurchases: PurchaseAction[] = [
-            {
-                target: {
-                    ...validInvoice,
-                    intent_id: '0xdifferent1'
-                },
-                purchase: {
-                    intentId: '0xexisting_intent1',
-                    params: {
-                        origin: '1',
-                        destinations: ['8453'],
-                        to: '0xdestination1',
-                        inputAsset: '0xtoken',
-                        amount: '1000000000000000000',
-                        callData: '0xdata1',
-                        maxFee: '0'
-                    } as NewIntentParams
-                },
-                transactionHash: '0xexisting1'
-            },
-            {
-                target: {
-                    ...validInvoice,
-                    ticker_hash: '0xdifferent_ticker',
-                    intent_id: '0xdifferent2'
-                },
-                purchase: {
-                    intentId: '0xexisting_intent2',
-                    params: {
-                        origin: '42161', // Different destination
-                        destinations: ['8453'],
-                        to: '0xdestination2',
-                        inputAsset: '0xtoken2',
-                        amount: '1000000000000000000',
-                        callData: '0xdata2',
-                        maxFee: '0'
-                    } as NewIntentParams
-                },
-                transactionHash: '0xexisting2'
-            }
-        ];
+    it('should filter out invalid invoices correctly', async () => {
+      // Create invoices with different invalid reasons
+      const validInvoice = createMockInvoice();
+      const zeroAmountInvoice = createMockInvoice({ 
+        intent_id: '0x456',
+        amount: '0' 
+      });
+      const invalidOwnerInvoice = createMockInvoice({ 
+        intent_id: '0x789',
+        owner: mockDeps.config.ownAddress
+      });
+      const tooNewInvoice = createMockInvoice({
+        intent_id: '0xabc',
+        hub_invoice_enqueued_timestamp: Date.now()
+      });
 
-        cache.getAllPurchases.resolves(existingPurchases);
+      const group: TickerGroup = {
+        ticker: '0xticker1',
+        invoices: [validInvoice, zeroAmountInvoice, invalidOwnerInvoice, tooNewInvoice],
+        remainingBalances: new Map([['0xticker1', new Map([['8453', BigInt('4000000000000000000')]])]]),
+        remainingCustodied: new Map([['0xticker1', new Map([['8453', BigInt('0')]])]]),
+        chosenOrigin: null
+      };
 
-        // Modify minAmounts to include multiple destinations
-        const multiDestResponse = {
-            ...validMinApiResponse,
-            minAmounts: {
-                '1': '1000000000000000000', // Should be filtered (same ticker)
-                '42161': '500000000000000000' // Should remain (different ticker)
-            }
-        };
-        everclear.getMinAmounts.resolves(multiDestResponse);
+      // Set up stubs for the valid invoice to be processed
+      isXerc20SupportedStub.resolves(false);
+      mockDeps.everclear.getMinAmounts.resolves({
+        minAmounts: { '8453': '1000000000000000000' },
+        invoiceAmount: '1000000000000000000',
+        amountAfterDiscount: '1000000000000000000',
+        discountBps: '0',
+        custodiedAmounts: {}
+      });
 
-        await processInvoices({
-            invoices: [validInvoice],
-            cache,
-            logger,
-            everclear,
-            chainService,
-            prometheus,
-            config: validConfig,
-            web3Signer: typedWeb3Signer
-        });
+      calculateSplitIntentsStub.resolves({
+        intents: [{
+          amount: '1000000000000000000',
+          origin: '8453',
+          destinations: ['1', '10'],
+          to: '0xowner',
+          inputAsset: '0xtoken1',
+          callData: '0x',
+          maxFee: '0'
+        }],
+        originDomain: '8453',
+        totalAllocated: BigInt('1000000000000000000')
+      });
 
-        // Verify calcSplitIntents was called with correctly filtered minAmounts
-        expect(calcSplitIntentsStub.calledOnce).to.be.true;
-        const filteredMinAmounts = calcSplitIntentsStub.firstCall.args[1];
-        expect(filteredMinAmounts).to.not.have.property('1'); // Should be filtered out (same ticker)
-        expect(filteredMinAmounts).to.have.property('42161'); // Should remain (different ticker)
+      sendIntentsStub.resolves([{
+        intentId: '0xabc',
+        transactionHash: '0xabc',
+        chainId: '8453'
+      }]);
+
+      const result = await processTickerGroup(mockContext, group, []);
+      
+      // Verify only the valid invoice made it through
+      expect(result.purchases.length).to.equal(1);
+      expect(result.purchases[0].target.intent_id).to.equal(validInvoice.intent_id);
+
+      // And prometheus metrics were recorded for invalid invoices
+      expect(mockDeps.prometheus.recordInvalidPurchase.callCount).to.equal(3);
+      expect(mockDeps.prometheus.recordInvalidPurchase.getCall(0).args[0]).to.equal(InvalidPurchaseReasons.InvalidFormat);
+      expect(mockDeps.prometheus.recordInvalidPurchase.getCall(1).args[0]).to.equal(InvalidPurchaseReasons.InvalidOwner);
+      expect(mockDeps.prometheus.recordInvalidPurchase.getCall(2).args[0]).to.equal(InvalidPurchaseReasons.InvalidAge);
     });
+
+    it('should skip the entire ticker group if a purchase is pending', async () => {
+      isXerc20SupportedStub.resolves(false);
+      mockDeps.everclear.getMinAmounts.resolves({
+        minAmounts: { '8453': '1000000000000000000' },
+        invoiceAmount: '1000000000000000000',
+        amountAfterDiscount: '1000000000000000000',
+        discountBps: '0',
+        custodiedAmounts: {}
+      });
+
+      const invoice = createMockInvoice({ intent_id: '0x123' });
+
+      const group: TickerGroup = {
+        ticker: '0xticker1',
+        invoices: [invoice],
+        remainingBalances: new Map([['0xticker1', new Map([['8453', BigInt('2000000000000000000')]])]]),
+        remainingCustodied: new Map([['0xticker1', new Map([['8453', BigInt('0')]])]]),
+        chosenOrigin: null
+      };
+
+      // Create a pending purchase for invoice1
+      const pendingPurchases = [{
+        target: invoice,
+        purchase: {
+          intentId: '0xexisting',
+          params: {
+            amount: '1000000000000000000',
+            origin: '8453',
+            destinations: ['1', '10'],
+            to: '0xowner',
+            inputAsset: '0xtoken1',
+            callData: '0x',
+            maxFee: '0'
+          }
+        },
+        transactionHash: '0xexisting'
+      }];
+
+      const result = await processTickerGroup(mockContext, group, pendingPurchases);
+      
+      // Should skip entire group, no purchases
+      expect(result.purchases).to.deep.equal([]);
+    });
+
+    it('should skip invoice if XERC20 is supported', async () => {
+      // Invoice has xerc20 support
+      isXerc20SupportedStub.onFirstCall().resolves(true);
+      
+      mockDeps.everclear.getMinAmounts.resolves({
+        minAmounts: { '8453': '1000000000000000000' },
+        invoiceAmount: '1000000000000000000',
+        amountAfterDiscount: '1000000000000000000',
+        discountBps: '0',
+        custodiedAmounts: {}
+      });
+
+      const invoice = createMockInvoice({ intent_id: '0x123' });
+
+      const group: TickerGroup = {
+        ticker: '0xticker1',
+        invoices: [invoice],
+        remainingBalances: new Map([['0xticker1', new Map([['8453', BigInt('2000000000000000000')]])]]),
+        remainingCustodied: new Map([['0xticker1', new Map([['8453', BigInt('0')]])]]),
+        chosenOrigin: null
+      };
+
+      const result = await processTickerGroup(mockContext, group, []);
+      
+      // Should skip the only invoice, no purchases
+      expect(result.purchases).to.deep.equal([]);
+    });
+
+    it('should filter out origins with pending purchases', async () => {
+      isXerc20SupportedStub.resolves(false);
+      mockDeps.everclear.getMinAmounts.resolves({
+        minAmounts: { '8453': '1000000000000000000', '10': '1000000000000000000' },
+        invoiceAmount: '1000000000000000000',
+        amountAfterDiscount: '1000000000000000000',
+        discountBps: '0',
+        custodiedAmounts: {}
+      });
+
+      const invoice = createMockInvoice();
+      const group: TickerGroup = {
+        ticker: '0xticker1',
+        invoices: [invoice],
+        remainingBalances: new Map([['0xticker1', new Map([
+          ['8453', BigInt('1000000000000000000')],
+          ['10', BigInt('1000000000000000000')]
+        ])]]),
+        remainingCustodied: new Map([['0xticker1', new Map([
+          ['8453', BigInt('0')],
+          ['10', BigInt('0')]
+        ])]]),
+        chosenOrigin: null
+      };
+
+      // Create a pending purchase for the same ticker on origin 8453
+      const pendingPurchases = [{
+        target: createMockInvoice({ intent_id: '0xother' }),
+        purchase: {
+          intentId: '0xexisting',
+          params: {
+            amount: '1000000000000000000',
+            origin: '8453', // This origin should be filtered out
+            destinations: ['1', '10'],
+            to: '0xowner',
+            inputAsset: '0xtoken1',
+            callData: '0x',
+            maxFee: '0'
+          }
+        },
+        transactionHash: '0xexisting'
+      }];
+
+      calculateSplitIntentsStub.resolves({
+        intents: [{
+          amount: '1000000000000000000',
+          origin: '10', // Should use origin 10 since 8453 is out
+          destinations: ['1', '8453'],
+          to: '0xowner',
+          inputAsset: '0xtoken1',
+          callData: '0x',
+          maxFee: '0'
+        }],
+        originDomain: '10',
+        totalAllocated: BigInt('1000000000000000000')
+      });
+
+      sendIntentsStub.resolves([{
+        intentId: '0xabc',
+        transactionHash: '0xabc',
+        chainId: '10'
+      }]);
+
+      const result = await processTickerGroup(mockContext, group, pendingPurchases);
+      
+      // Verify the purchase uses origin 10
+      expect(result.purchases.length).to.equal(1);
+      expect(result.purchases[0].purchase.params.origin).to.equal('10');
+    });
+
+    it('should skip other invoices when prioritizeOldestInvoice is true and oldest invoice has no valid allocation', async () => {
+      mockDeps.config.prioritizeOldestInvoice = true;
+      isXerc20SupportedStub.resolves(false);
+
+      const oldestInvoice = createMockInvoice({
+        intent_id: '0x123',
+        hub_invoice_enqueued_timestamp: Date.now() - 7200000 // 2 hours old
+      });
+      const newerInvoice = createMockInvoice({
+        intent_id: '0x456',
+        hub_invoice_enqueued_timestamp: Date.now() - 3600000 // 1 hour old
+      });
+
+      const group: TickerGroup = {
+        ticker: '0xticker1',
+        invoices: [oldestInvoice, newerInvoice],
+        remainingBalances: new Map([['0xticker1', new Map([['8453', BigInt('2000000000000000000')]])]]),
+        remainingCustodied: new Map([['0xticker1', new Map([['8453', BigInt('0')]])]]),
+        chosenOrigin: null
+      };
+
+      mockDeps.everclear.getMinAmounts.resolves({
+        minAmounts: { '8453': '1000000000000000000' },
+        invoiceAmount: '1000000000000000000',
+        amountAfterDiscount: '1000000000000000000',
+        discountBps: '0',
+        custodiedAmounts: {}
+      });
+
+      // No valid allocation for the oldest invoice
+      calculateSplitIntentsStub.resolves({
+        intents: [],
+        originDomain: null,
+        totalAllocated: BigInt('0')
+      });
+
+      const result = await processTickerGroup(mockContext, group, []);
+      
+      // Skip entire group since oldest invoice couldn't be processed, no purchases
+      expect(result.purchases).to.deep.equal([]);
+    });
+
+    it('should process newer invoices when prioritizeOldestInvoice is false and oldest invoice has no valid allocation', async () => {
+      mockDeps.config.prioritizeOldestInvoice = false;
+      isXerc20SupportedStub.resolves(false);
+
+      const oldestInvoice = createMockInvoice({
+        intent_id: '0x123',
+        hub_invoice_enqueued_timestamp: Date.now() - 7200000 // 2 hours old
+      });
+      const newerInvoice = createMockInvoice({
+        intent_id: '0x456',
+        hub_invoice_enqueued_timestamp: Date.now() - 3600000 // 1 hour old
+      });
+
+      const group: TickerGroup = {
+        ticker: '0xticker1',
+        invoices: [oldestInvoice, newerInvoice],
+        remainingBalances: new Map([['0xticker1', new Map([['8453', BigInt('2000000000000000000')]])]]),
+        remainingCustodied: new Map([['0xticker1', new Map([['8453', BigInt('0')]])]]),
+        chosenOrigin: null
+      };
+
+      mockDeps.everclear.getMinAmounts.resolves({
+        minAmounts: { '8453': '1000000000000000000' },
+        invoiceAmount: '1000000000000000000',
+        amountAfterDiscount: '1000000000000000000',
+        discountBps: '0',
+        custodiedAmounts: {}
+      });
+
+      // No valid allocation for oldest invoice
+      calculateSplitIntentsStub.onFirstCall().resolves({
+        intents: [],
+        originDomain: null,
+        totalAllocated: BigInt('0')
+      });
+
+      // Valid allocation for newer invoice
+      calculateSplitIntentsStub.onSecondCall().resolves({
+        intents: [{
+          amount: '1000000000000000000',
+          origin: '8453',
+          destinations: ['1', '10'],
+          to: '0xowner',
+          inputAsset: '0xtoken1',
+          callData: '0x',
+          maxFee: '0'
+        }],
+        originDomain: '8453',
+        totalAllocated: BigInt('1000000000000000000')
+      });
+
+      sendIntentsStub.resolves([{
+        intentId: '0xabc',
+        transactionHash: '0xabc',
+        chainId: '8453'
+      }]);
+
+      const result = await processTickerGroup(mockContext, group, []);
+      
+      // Should process newer invoice
+      expect(result.purchases.length).to.equal(1);
+      expect(result.purchases[0].target.intent_id).to.equal(newerInvoice.intent_id);
+    });
+
+    it('should use the same origin for all invoices in a group once chosen', async () => {
+      isXerc20SupportedStub.resolves(false);
+      
+      const invoice1 = createMockInvoice({ intent_id: '0x123' });
+      const invoice2 = createMockInvoice({ intent_id: '0x456' });
+      const invoice3 = createMockInvoice({ intent_id: '0x789' });
+
+      const group: TickerGroup = {
+        ticker: '0xticker1',
+        invoices: [invoice1, invoice2, invoice3],
+        remainingBalances: new Map([['0xticker1', new Map([
+          ['8453', BigInt('3000000000000000000')],
+          ['10', BigInt('3000000000000000000')]
+        ])]]),
+        remainingCustodied: new Map([['0xticker1', new Map([
+          ['8453', BigInt('0')],
+          ['10', BigInt('0')]
+        ])]]),
+        chosenOrigin: null
+      };
+
+      // Both origins (8453 and 10) are valid options
+      mockDeps.everclear.getMinAmounts.resolves({
+        minAmounts: { 
+          '8453': '1000000000000000000',
+          '10': '1000000000000000000'
+        },
+        invoiceAmount: '1000000000000000000',
+        amountAfterDiscount: '1000000000000000000',
+        discountBps: '0',
+        custodiedAmounts: {}
+      });
+
+      // First invoice chooses origin 8453
+      calculateSplitIntentsStub.resolves({
+        intents: [{
+          amount: '1000000000000000000',
+          origin: '8453',
+          destinations: ['1', '10'],
+          to: '0xowner',
+          inputAsset: '0xtoken1',
+          callData: '0x',
+          maxFee: '0'
+        }],
+        originDomain: '8453',
+        totalAllocated: BigInt('1000000000000000000')
+      });
+
+      sendIntentsStub.resolves([
+        {
+          intentId: '0xabc1',
+          transactionHash: '0xabc1',
+          chainId: '8453'
+        },
+        {
+          intentId: '0xabc2',
+          transactionHash: '0xabc2',
+          chainId: '8453'
+        },
+        {
+          intentId: '0xabc3',
+          transactionHash: '0xabc3',
+          chainId: '8453'
+        }
+      ]);
+
+      const result = await processTickerGroup(mockContext, group, []);
+      
+      // Verify all purchases use the same origin
+      expect(result.purchases.length).to.equal(3);
+      result.purchases.forEach(purchase => {
+        expect(purchase.purchase.params.origin).to.equal('8453');
+      });
+
+      // Verify the remaining balances were updated correctly for the chosen origin
+      expect(result.remainingBalances.get('0xticker1')?.get('8453')).to.equal(BigInt('0'));
+    });
+
+    it('should handle getMinAmounts failure gracefully', async () => {
+      isXerc20SupportedStub.resolves(false);
+      mockDeps.everclear.getMinAmounts.rejects(new Error('API Error'));
+
+      const invoice = createMockInvoice();
+      const group: TickerGroup = {
+        ticker: '0xticker1',
+        invoices: [invoice],
+        remainingBalances: new Map([['0xticker1', new Map([['8453', BigInt('1000000000000000000')]])]]),
+        remainingCustodied: new Map([['0xticker1', new Map([['8453', BigInt('0')]])]]),
+        chosenOrigin: null
+      };
+
+      calculateSplitIntentsStub.resolves({
+        intents: [{
+          amount: '1000000000000000000',
+          origin: '8453',
+          destinations: ['1', '10'],
+          to: '0xowner',
+          inputAsset: '0xtoken1',
+          callData: '0x',
+          maxFee: '0'
+        }],
+        originDomain: '8453',
+        totalAllocated: BigInt('1000000000000000000')
+      });
+
+      sendIntentsStub.resolves([{
+        intentId: '0xabc',
+        transactionHash: '0xabc',
+        chainId: '8453'
+      }]);
+
+      const result = await processTickerGroup(mockContext, group, []);
+      
+      // Verify that the invoice was still processed with default '0' amounts
+      expect(calculateSplitIntentsStub.calledOnce).to.be.true;
+      expect(calculateSplitIntentsStub.firstCall.args[1]).to.deep.equal({ '8453': '0' });
+    });
+
+    it('should handle sendIntents failure gracefully', async () => {
+      isXerc20SupportedStub.resolves(false);
+      mockDeps.everclear.getMinAmounts.resolves({
+        minAmounts: { '8453': '1000000000000000000' },
+        invoiceAmount: '1000000000000000000',
+        amountAfterDiscount: '1000000000000000000',
+        discountBps: '0',
+        custodiedAmounts: {}
+      });
+
+      const invoice = createMockInvoice();
+      const group: TickerGroup = {
+        ticker: '0xticker1',
+        invoices: [invoice],
+        remainingBalances: new Map([['0xticker1', new Map([['8453', BigInt('1000000000000000000')]])]]),
+        remainingCustodied: new Map([['0xticker1', new Map([['8453', BigInt('0')]])]]),
+        chosenOrigin: null
+      };
+
+      calculateSplitIntentsStub.resolves({
+        intents: [{
+          amount: '1000000000000000000',
+          origin: '8453',
+          destinations: ['1', '10'],
+          to: '0xowner',
+          inputAsset: '0xtoken1',
+          callData: '0x',
+          maxFee: '0'
+        }],
+        originDomain: '8453',
+        totalAllocated: BigInt('1000000000000000000')
+      });
+
+      sendIntentsStub.rejects(new Error('Transaction failed'));
+
+      try {
+        await processTickerGroup(mockContext, group, []);
+        expect.fail('Should have thrown an error');
+      } catch (error: any) {
+        expect(error.message).to.equal('Transaction failed');
+        expect(mockDeps.prometheus.recordInvalidPurchase.calledOnce).to.be.true;
+        expect(mockDeps.prometheus.recordInvalidPurchase.firstCall.args[0]).to.equal(InvalidPurchaseReasons.TransactionFailed);
+      }
+    });
+
+    it('should map split intents to their respective invoices correctly', async () => {
+      getMarkBalancesStub.resolves(new Map());
+      getMarkGasBalancesStub.resolves(new Map());
+      getCustodiedBalancesStub.resolves(new Map());
+      isXerc20SupportedStub.resolves(false);
+      mockDeps.cache.getAllPurchases.resolves([]);
+      mockDeps.everclear.intentStatus.resolves(IntentStatus.ADDED);
+
+      const invoice1 = createMockInvoice({
+        intent_id: '0x123',
+        origin: '1',
+        destinations: ['8453'],
+        amount: '1000000000000000000'
+      });
+      
+      const invoice2 = createMockInvoice({
+        intent_id: '0x456',
+        origin: '1',
+        destinations: ['8453'],
+        amount: '1000000000000000000'
+      });
+
+      mockDeps.everclear.getMinAmounts.resolves({
+        minAmounts: { 
+          '8453': '1000000000000000000'
+        },
+        invoiceAmount: '1000000000000000000',
+        amountAfterDiscount: '1000000000000000000',
+        discountBps: '0',
+        custodiedAmounts: {}
+      });
+
+      // First invoice gets two split intents
+      calculateSplitIntentsStub.onFirstCall().resolves({
+        intents: [
+          {
+            amount: '500000000000000000',
+            origin: '8453',
+            destinations: ['1', '10'],
+            to: '0xowner',
+            inputAsset: '0xtoken1',
+            callData: '0x',
+            maxFee: '0'
+          },
+          {
+            amount: '500000000000000000',
+            origin: '8453',
+            destinations: ['10', '1'],
+            to: '0xowner',
+            inputAsset: '0xtoken1',
+            callData: '0x',
+            maxFee: '0'
+          }
+        ],
+        originDomain: '8453',
+        totalAllocated: BigInt('1000000000000000000')
+      });
+
+      // Second invoice gets a single intent
+      calculateSplitIntentsStub.onSecondCall().resolves({
+        intents: [
+          {
+            amount: '1000000000000000000',
+            origin: '8453',
+            destinations: ['1', '10'],
+            to: '0xowner',
+            inputAsset: '0xtoken1',
+            callData: '0x',
+            maxFee: '0'
+          }
+        ],
+        originDomain: '8453',
+        totalAllocated: BigInt('1000000000000000000')
+      });
+
+      // Three txs total (2 for first invoice, 1 for second)
+      sendIntentsStub.resolves([
+        {
+          intentId: '0xabc1',
+          transactionHash: '0xabc1',
+          chainId: '8453'
+        },
+        {
+          intentId: '0xabc2',
+          transactionHash: '0xabc2',
+          chainId: '8453'
+        },
+        {
+          intentId: '0xdef',
+          transactionHash: '0xdef',
+          chainId: '8453'
+        }
+      ]);
+      
+      await processInvoices(mockContext, [invoice1, invoice2]);
+
+      const expectedPurchases = [
+        {
+          target: invoice1,  // First two purchases target invoice1
+          transactionHash: '0xabc1',
+          purchase: {
+            intentId: '0xabc1',
+            params: {
+              amount: '500000000000000000',
+              origin: '8453',
+              destinations: ['1', '10'],
+              to: '0xowner',
+              inputAsset: '0xtoken1',
+              callData: '0x',
+              maxFee: '0'
+            }
+          }
+        },
+        {
+          target: invoice1,  // First two purchases target invoice1
+          transactionHash: '0xabc2',
+          purchase: {
+            intentId: '0xabc2',
+            params: {
+              amount: '500000000000000000',
+              origin: '8453',
+              destinations: ['10', '1'],
+              to: '0xowner',
+              inputAsset: '0xtoken1',
+              callData: '0x',
+              maxFee: '0'
+            }
+          }
+        },
+        {
+          target: invoice2,  // Third purchase targets invoice2
+          transactionHash: '0xdef',
+          purchase: {
+            intentId: '0xdef',
+            params: {
+              amount: '1000000000000000000',
+              origin: '8453',
+              destinations: ['1', '10'],
+              to: '0xowner',
+              inputAsset: '0xtoken1',
+              callData: '0x',
+              maxFee: '0'
+            }
+          }
+        }
+      ];
+
+      // Verify the correct purchases were stored in cache with proper invoice mapping
+      expect(mockDeps.cache.addPurchases.calledOnce).to.be.true;
+      expect(mockDeps.cache.addPurchases.firstCall.args[0]).to.deep.equal(expectedPurchases);
+    });
+  });
 });

--- a/packages/poller/test/mocks.ts
+++ b/packages/poller/test/mocks.ts
@@ -1,0 +1,114 @@
+import { Invoice, MarkConfiguration } from '@mark/core';
+
+// Default single-dest mock invoice, optional override fields
+export function createMockInvoice(overrides?: Partial<Invoice>): Invoice {
+  return {
+    intent_id: '0x123',
+    amount: '1000000000000000000',
+    origin: '1',
+    destinations: ['8453'],
+    ticker_hash: '0xticker1',
+    hub_invoice_enqueued_timestamp: Date.now() - 7200000,
+    source_domain: '1',
+    target_domain: '8453',
+    source_address: '0xsource',
+    target_address: '0xtarget',
+    source_token_address: '0xtoken1',
+    target_token_address: '0xtoken2',
+    status: 'PENDING',
+    owner: '0xowner',
+    entry_epoch: 0,
+    discountBps: 0,
+    hub_status: 'PENDING',
+    severity: 0,
+    ...overrides,
+  } as Invoice;
+}
+
+export const mockConfig: MarkConfiguration = {
+  pushGatewayUrl: 'http://localhost:9091',
+  web3SignerUrl: 'http://localhost:8545',
+  everclearApiUrl: 'http://localhost:3000',
+  relayer: {
+    url: 'http://localhost:8080',
+  },
+  redis: {
+    host: 'localhost',
+    port: 6379
+  },
+  ownAddress: '0x1234567890123456789012345678901234567890',
+  stage: 'development',
+  environment: 'devnet',
+  logLevel: 'debug',
+  supportedSettlementDomains: [1, 8453],
+  prioritizeOldestInvoice: false,
+  supportedAssets: ['0xticker1'],
+  chains: {
+    '1': {
+      providers: ['http://localhost:8545'],
+      assets: [{
+        tickerHash: '0xticker1',
+        address: '0xtoken1',
+        decimals: 18,
+        symbol: 'TEST',
+        isNative: false,
+        balanceThreshold: '1000000000000000000',
+      }],
+      deployments: {
+        everclear: '0x1234567890123456789012345678901234567890',
+        permit2: '0x1234567890123456789012345678901234567890',
+        multicall3: '0x1234567890123456789012345678901234567890'
+      },
+      invoiceAge: 3600,
+      gasThreshold: '1000000000000000000'
+    },
+    '8453': {
+      providers: ['http://localhost:8545'],
+      assets: [{
+        tickerHash: '0xticker1',
+        address: '0xtoken1',
+        decimals: 18,
+        symbol: 'TEST',
+        isNative: false,
+        balanceThreshold: '1000000000000000000',
+      }],
+      deployments: {
+        everclear: '0x1234567890123456789012345678901234567890',
+        permit2: '0x1234567890123456789012345678901234567890',
+        multicall3: '0x1234567890123456789012345678901234567890'
+      },
+      invoiceAge: 3600,
+      gasThreshold: '1000000000000000000'
+    },
+    '10': {
+      providers: ['http://localhost:8545'],
+      assets: [{
+        tickerHash: '0xticker1',
+        address: '0xtoken1',
+        decimals: 18,
+        symbol: 'TEST',
+        isNative: false,
+        balanceThreshold: '1000000000000000000',
+      }],
+      deployments: {
+        everclear: '0x1234567890123456789012345678901234567890',
+        permit2: '0x1234567890123456789012345678901234567890',
+        multicall3: '0x1234567890123456789012345678901234567890'
+      },
+      invoiceAge: 3600,
+      gasThreshold: '1000000000000000000'
+    },
+  },
+  hub: {
+    domain: '1',
+    providers: ['http://localhost:8545'],
+    assets: [{
+      tickerHash: '0xticker1',
+      address: '0xtoken1',
+      decimals: 18,
+      symbol: 'TEST',
+      isNative: false,
+      balanceThreshold: '1000000000000000000'
+    }]
+  }
+}

--- a/packages/poller/test/mocks.ts
+++ b/packages/poller/test/mocks.ts
@@ -41,7 +41,7 @@ export const mockConfig: MarkConfiguration = {
   environment: 'devnet',
   logLevel: 'debug',
   supportedSettlementDomains: [1, 8453],
-  prioritizeOldestInvoice: false,
+  forceOldestInvoice: false,
   supportedAssets: ['0xticker1'],
   chains: {
     '1': {

--- a/packages/poller/tsconfig.json
+++ b/packages/poller/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
     "baseUrl": ".",
     "paths": {
       "#/*": ["./src/*", "./test/*"]


### PR DESCRIPTION
Invoices are grouped by ticker and sorted by age (oldest first)

For each ticker group:
- the first invoice is evaluated against all of its possible destinations (candidate origins for Mark)
- once a purchasable invoice is found, all subsequent invoices in that ticker group will be evaluated with the same origin (for batching purposes)
- each invoice can still be split into multiple intents if it's more optimal, but has to be the same origin
- maintains a BatchedTickerGroup that tracks the chosen origin, all invoices, and their associated intents 
- individual intents in batch are sent in individual txns (will be combined into single txns thru fee adapter)