### PR TITLE
fix: add build tools for native dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,14 +136,10 @@ jobs:
           node-version: '20'
           cache: 'yarn'
 
-      - name: Install build tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential python3
-          npm install -g node-gyp
-
       - name: Install dependencies
         run: yarn install
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
@@ -235,14 +231,10 @@ jobs:
           node-version: '20'
           cache: 'yarn'
 
-      - name: Install build tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential python3
-          npm install -g node-gyp
-
       - name: Install dependencies
         run: yarn install
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1


### PR DESCRIPTION
Fixes yarn install failures in CI by adding necessary build tools (gcc, make, python3, node-gyp) for compiling native dependencies